### PR TITLE
Fix/auth boundary

### DIFF
--- a/crates/spur-cloud-api/src/auth/jwt.rs
+++ b/crates/spur-cloud-api/src/auth/jwt.rs
@@ -66,15 +66,8 @@ mod tests {
     #[test]
     fn verify_token_returns_principal_with_expected_claims() {
         let user_id = Uuid::new_v4();
-        let token = generate_token(
-            "test-secret",
-            user_id,
-            "user@example.com",
-            "alice",
-            true,
-            1,
-        )
-        .unwrap();
+        let token =
+            generate_token("test-secret", user_id, "user@example.com", "alice", true, 1).unwrap();
 
         let principal = verify_token("test-secret", &token).unwrap();
 

--- a/crates/spur-cloud-api/src/auth/jwt.rs
+++ b/crates/spur-cloud-api/src/auth/jwt.rs
@@ -3,6 +3,8 @@ use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation}
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::auth::principal::Principal;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
     pub sub: String, // user ID
@@ -11,15 +13,6 @@ pub struct Claims {
     pub admin: bool,
     pub exp: i64, // expiry (unix timestamp)
     pub iat: i64, // issued at
-}
-
-/// Identity extracted from a verified JWT. Available in route handlers.
-#[derive(Debug, Clone)]
-pub struct Identity {
-    pub user_id: Uuid,
-    pub email: String,
-    pub username: String,
-    pub is_admin: bool,
 }
 
 pub fn generate_token(
@@ -47,17 +40,63 @@ pub fn generate_token(
     Ok(token)
 }
 
-pub fn verify_token(secret: &str, token: &str) -> anyhow::Result<Identity> {
+pub fn verify_token(secret: &str, token: &str) -> anyhow::Result<Principal> {
     let data = decode::<Claims>(
         token,
         &DecodingKey::from_secret(secret.as_bytes()),
         &Validation::default(),
     )?;
     let user_id = Uuid::parse_str(&data.claims.sub)?;
-    Ok(Identity {
+    Ok(Principal {
         user_id,
         email: data.claims.email,
         username: data.claims.username,
         is_admin: data.claims.admin,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{generate_token, verify_token};
+    use crate::auth::principal::Principal;
+    use uuid::Uuid;
+
+    fn assert_principal(_: &Principal) {}
+
+    #[test]
+    fn verify_token_returns_principal_with_expected_claims() {
+        let user_id = Uuid::new_v4();
+        let token = generate_token(
+            "test-secret",
+            user_id,
+            "user@example.com",
+            "alice",
+            true,
+            1,
+        )
+        .unwrap();
+
+        let principal = verify_token("test-secret", &token).unwrap();
+
+        assert_principal(&principal);
+        assert_eq!(principal.user_id, user_id);
+        assert_eq!(principal.email, "user@example.com");
+        assert_eq!(principal.username, "alice");
+        assert!(principal.is_admin);
+    }
+
+    #[test]
+    fn verify_token_rejects_wrong_secret() {
+        let token = generate_token(
+            "test-secret",
+            Uuid::new_v4(),
+            "user@example.com",
+            "alice",
+            false,
+            1,
+        )
+        .unwrap();
+
+        assert!(verify_token("wrong-secret", &token).is_err());
+    }
 }

--- a/crates/spur-cloud-api/src/auth/middleware.rs
+++ b/crates/spur-cloud-api/src/auth/middleware.rs
@@ -5,11 +5,11 @@ use axum::{
     response::{IntoResponse, Response},
 };
 
-use crate::auth::jwt::{verify_token, Identity};
+use crate::auth::jwt::verify_token;
 use crate::state::AppState;
 
 /// Axum middleware that extracts and verifies JWT from Authorization header.
-/// On success, inserts `Identity` into request extensions.
+/// On success, inserts `Principal` into request extensions.
 pub async fn auth_middleware(
     State(state): State<AppState>,
     mut request: Request,
@@ -43,15 +43,137 @@ pub async fn auth_middleware(
     let token = &token;
 
     match verify_token(&state.config.auth.jwt_secret, token) {
-        Ok(identity) => {
-            request.extensions_mut().insert(identity);
+        Ok(principal) => {
+            request.extensions_mut().insert(principal);
             next.run(request).await
         }
         Err(_) => (StatusCode::UNAUTHORIZED, "invalid or expired token").into_response(),
     }
 }
 
-/// Extractor for Identity from request extensions (set by auth_middleware).
-pub fn get_identity(request: &Request) -> Option<&Identity> {
-    request.extensions().get::<Identity>()
+#[cfg(test)]
+mod tests {
+    use super::auth_middleware;
+    use crate::{
+        auth::{jwt::generate_token, principal::Principal},
+        config::{AuthConfig, Config, DatabaseConfig, ServerConfig, SpurConfig},
+        state::AppState,
+    };
+    use axum::{
+        body::{to_bytes, Body},
+        http::{Request, Response, StatusCode},
+        middleware,
+        response::IntoResponse,
+        routing::get,
+        Extension, Router,
+    };
+    use kube::client::Body as KubeBody;
+    use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
+    use sqlx::postgres::PgPoolOptions;
+    use std::{convert::Infallible, sync::Arc};
+    use tonic::transport::Channel;
+    use tower::{service_fn, util::ServiceExt};
+    use uuid::Uuid;
+
+    async fn protected(Extension(principal): Extension<Principal>) -> impl IntoResponse {
+        principal.user_id.to_string()
+    }
+
+    fn test_state(secret: &str) -> AppState {
+        let db = PgPoolOptions::new()
+            .connect_lazy("postgresql://postgres:postgres@localhost/test")
+            .unwrap();
+        let spur = SlurmControllerClient::new(Channel::from_static("http://localhost").connect_lazy());
+        let kube = kube::Client::new(
+            service_fn(|_request| async {
+                Ok::<_, Infallible>(
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .body(KubeBody::empty())
+                        .unwrap(),
+                )
+            }),
+            "default",
+        );
+
+        AppState {
+            db,
+            spur,
+            kube: Some(kube),
+            config: Arc::new(Config {
+                public_url: "http://localhost:3000".into(),
+                database: DatabaseConfig {
+                    url: "postgresql://postgres:postgres@localhost/test".into(),
+                },
+                spur: SpurConfig {
+                    controller_addr: "http://localhost:6817".into(),
+                },
+                auth: AuthConfig {
+                    jwt_secret: secret.into(),
+                    jwt_expiry_hours: 24,
+                    github: None,
+                    okta: None,
+                },
+                server: ServerConfig::default(),
+                bare_metal: None,
+            }),
+        }
+    }
+
+    fn protected_router(secret: &str) -> Router {
+        let state = test_state(secret);
+
+        Router::new()
+            .route("/protected", get(protected))
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                auth_middleware,
+            ))
+            .with_state(state)
+    }
+
+    #[tokio::test]
+    async fn middleware_rejects_missing_authorization_header() {
+        let response = protected_router("test-secret")
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn middleware_inserts_principal_for_valid_token() {
+        let user_id = Uuid::new_v4();
+        let token = generate_token(
+            "test-secret",
+            user_id,
+            "user@example.com",
+            "alice",
+            true,
+            1,
+        )
+        .unwrap();
+
+        let response = protected_router("test-secret")
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(std::str::from_utf8(&body).unwrap(), user_id.to_string());
+    }
 }

--- a/crates/spur-cloud-api/src/auth/middleware.rs
+++ b/crates/spur-cloud-api/src/auth/middleware.rs
@@ -83,7 +83,8 @@ mod tests {
         let db = PgPoolOptions::new()
             .connect_lazy("postgresql://postgres:postgres@localhost/test")
             .unwrap();
-        let spur = SlurmControllerClient::new(Channel::from_static("http://localhost").connect_lazy());
+        let spur =
+            SlurmControllerClient::new(Channel::from_static("http://localhost").connect_lazy());
         let kube = kube::Client::new(
             service_fn(|_request| async {
                 Ok::<_, Infallible>(
@@ -150,15 +151,8 @@ mod tests {
     #[tokio::test]
     async fn middleware_inserts_principal_for_valid_token() {
         let user_id = Uuid::new_v4();
-        let token = generate_token(
-            "test-secret",
-            user_id,
-            "user@example.com",
-            "alice",
-            true,
-            1,
-        )
-        .unwrap();
+        let token =
+            generate_token("test-secret", user_id, "user@example.com", "alice", true, 1).unwrap();
 
         let response = protected_router("test-secret")
             .oneshot(

--- a/crates/spur-cloud-api/src/auth/mod.rs
+++ b/crates/spur-cloud-api/src/auth/mod.rs
@@ -1,6 +1,6 @@
 pub mod github;
 pub mod jwt;
 pub mod middleware;
-pub mod principal;
 pub mod oidc_common;
 pub mod okta;
+pub mod principal;

--- a/crates/spur-cloud-api/src/auth/mod.rs
+++ b/crates/spur-cloud-api/src/auth/mod.rs
@@ -1,5 +1,6 @@
 pub mod github;
 pub mod jwt;
 pub mod middleware;
+pub mod principal;
 pub mod oidc_common;
 pub mod okta;

--- a/crates/spur-cloud-api/src/auth/principal.rs
+++ b/crates/spur-cloud-api/src/auth/principal.rs
@@ -1,0 +1,10 @@
+use uuid::Uuid;
+
+/// Authenticated caller normalized at the application boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Principal {
+    pub user_id: Uuid,
+    pub email: String,
+    pub username: String,
+    pub is_admin: bool,
+}

--- a/crates/spur-cloud-api/src/routes/billing.rs
+++ b/crates/spur-cloud-api/src/routes/billing.rs
@@ -7,7 +7,7 @@ use axum::{
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
-use crate::auth::jwt::Identity;
+use crate::auth::principal::Principal;
 use crate::db::billing_repo;
 use crate::state::AppState;
 
@@ -20,10 +20,10 @@ pub struct UsageParams {
 /// GET /api/billing/usage — list usage records
 pub async fn get_usage(
     State(state): State<AppState>,
-    Extension(identity): Extension<Identity>,
+    Extension(principal): Extension<Principal>,
     Query(params): Query<UsageParams>,
 ) -> impl IntoResponse {
-    match billing_repo::get_usage(&state.db, identity.user_id, params.since, params.until).await {
+    match billing_repo::get_usage(&state.db, principal.user_id, params.since, params.until).await {
         Ok(records) => Json(records).into_response(),
         Err(e) => {
             tracing::error!("billing query failed: {e}");
@@ -35,10 +35,10 @@ pub async fn get_usage(
 /// GET /api/billing/summary — aggregated usage summary
 pub async fn get_summary(
     State(state): State<AppState>,
-    Extension(identity): Extension<Identity>,
+    Extension(principal): Extension<Principal>,
     Query(params): Query<UsageParams>,
 ) -> impl IntoResponse {
-    match billing_repo::get_usage_summary(&state.db, identity.user_id, params.since).await {
+    match billing_repo::get_usage_summary(&state.db, principal.user_id, params.since).await {
         Ok(summary) => Json(summary).into_response(),
         Err(e) => {
             tracing::error!("billing summary failed: {e}");

--- a/crates/spur-cloud-api/src/routes/sessions.rs
+++ b/crates/spur-cloud-api/src/routes/sessions.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use tracing::{error, info};
 use uuid::Uuid;
 
-use crate::auth::jwt::Identity;
+use crate::auth::principal::Principal;
 use crate::config::Backend;
 use crate::db::{session_repo, ssh_key_repo};
 use crate::models::session::SessionDetail;
@@ -31,7 +31,7 @@ fn default_limit() -> i64 {
 /// POST /api/sessions — launch a new GPU session
 pub async fn create_session(
     State(state): State<AppState>,
-    Extension(identity): Extension<Identity>,
+    Extension(principal): Extension<Principal>,
     Json(req): Json<CreateSessionRequest>,
 ) -> impl IntoResponse {
     // Validate
@@ -42,7 +42,7 @@ pub async fn create_session(
     // Create session in DB
     let session = match session_repo::create_session(
         &state.db,
-        identity.user_id,
+        principal.user_id,
         &req.name,
         &req.gpu_type,
         req.gpu_count,
@@ -62,7 +62,7 @@ pub async fn create_session(
 
     // Get SSH keys if SSH enabled
     let ssh_keys_str = if req.ssh_enabled {
-        match ssh_key_repo::get_keys_for_user(&state.db, identity.user_id).await {
+        match ssh_key_repo::get_keys_for_user(&state.db, principal.user_id).await {
             Ok(keys) => keys
                 .iter()
                 .map(|k| k.public_key.as_str())
@@ -123,12 +123,12 @@ pub async fn create_session(
 /// GET /api/sessions — list user's sessions
 pub async fn list_sessions(
     State(state): State<AppState>,
-    Extension(identity): Extension<Identity>,
+    Extension(principal): Extension<Principal>,
     Query(params): Query<ListParams>,
 ) -> impl IntoResponse {
     match session_repo::list_sessions_for_user(
         &state.db,
-        identity.user_id,
+        principal.user_id,
         params.state.as_deref(),
         params.limit,
     )
@@ -148,10 +148,10 @@ pub async fn list_sessions(
 /// GET /api/sessions/:id — get session detail
 pub async fn get_session(
     State(state): State<AppState>,
-    Extension(identity): Extension<Identity>,
+    Extension(principal): Extension<Principal>,
     Path(id): Path<Uuid>,
 ) -> impl IntoResponse {
-    match session_repo::get_session_for_user(&state.db, id, identity.user_id).await {
+    match session_repo::get_session_for_user(&state.db, id, principal.user_id).await {
         Ok(Some(session)) => {
             let detail: SessionDetail = session.into();
             Json(detail).into_response()
@@ -167,10 +167,10 @@ pub async fn get_session(
 /// DELETE /api/sessions/:id — cancel/terminate session
 pub async fn delete_session(
     State(state): State<AppState>,
-    Extension(identity): Extension<Identity>,
+    Extension(principal): Extension<Principal>,
     Path(id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let session = match session_repo::get_session_for_user(&state.db, id, identity.user_id).await {
+    let session = match session_repo::get_session_for_user(&state.db, id, principal.user_id).await {
         Ok(Some(s)) => s,
         Ok(None) => return (StatusCode::NOT_FOUND, "session not found").into_response(),
         Err(e) => {

--- a/crates/spur-cloud-api/src/routes/users.rs
+++ b/crates/spur-cloud-api/src/routes/users.rs
@@ -7,7 +7,7 @@ use axum::{
 use serde::Deserialize;
 use uuid::Uuid;
 
-use crate::auth::jwt::Identity;
+use crate::auth::principal::Principal;
 use crate::db::{ssh_key_repo, user_repo};
 use crate::models::user::UserProfile;
 use crate::state::AppState;
@@ -15,9 +15,9 @@ use crate::state::AppState;
 /// GET /api/users/me — get current user profile
 pub async fn get_profile(
     State(state): State<AppState>,
-    Extension(identity): Extension<Identity>,
+    Extension(principal): Extension<Principal>,
 ) -> impl IntoResponse {
-    match user_repo::get_user_by_id(&state.db, identity.user_id).await {
+    match user_repo::get_user_by_id(&state.db, principal.user_id).await {
         Ok(Some(user)) => {
             let profile: UserProfile = user.into();
             Json(profile).into_response()
@@ -36,9 +36,9 @@ pub struct AddSshKeyRequest {
 /// GET /api/users/me/ssh-keys — list SSH keys
 pub async fn list_ssh_keys(
     State(state): State<AppState>,
-    Extension(identity): Extension<Identity>,
+    Extension(principal): Extension<Principal>,
 ) -> impl IntoResponse {
-    match ssh_key_repo::list_keys(&state.db, identity.user_id).await {
+    match ssh_key_repo::list_keys(&state.db, principal.user_id).await {
         Ok(keys) => Json(keys).into_response(),
         Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "failed").into_response(),
     }
@@ -47,7 +47,7 @@ pub async fn list_ssh_keys(
 /// POST /api/users/me/ssh-keys — add SSH key
 pub async fn add_ssh_key(
     State(state): State<AppState>,
-    Extension(identity): Extension<Identity>,
+    Extension(principal): Extension<Principal>,
     Json(req): Json<AddSshKeyRequest>,
 ) -> impl IntoResponse {
     // Validate SSH key format
@@ -61,7 +61,7 @@ pub async fn add_ssh_key(
 
     match ssh_key_repo::add_key(
         &state.db,
-        identity.user_id,
+        principal.user_id,
         &req.name,
         req.public_key.trim(),
         &fingerprint,
@@ -83,10 +83,10 @@ pub async fn add_ssh_key(
 /// DELETE /api/users/me/ssh-keys/:id — delete SSH key
 pub async fn delete_ssh_key(
     State(state): State<AppState>,
-    Extension(identity): Extension<Identity>,
+    Extension(principal): Extension<Principal>,
     Path(id): Path<Uuid>,
 ) -> impl IntoResponse {
-    match ssh_key_repo::delete_key(&state.db, id, identity.user_id).await {
+    match ssh_key_repo::delete_key(&state.db, id, principal.user_id).await {
         Ok(true) => StatusCode::NO_CONTENT.into_response(),
         Ok(false) => (StatusCode::NOT_FOUND, "key not found").into_response(),
         Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "failed").into_response(),

--- a/crates/spur-cloud-api/src/routes/ws.rs
+++ b/crates/spur-cloud-api/src/routes/ws.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use uuid::Uuid;
 
-use crate::auth::jwt::Identity;
+use crate::auth::principal::Principal;
 use crate::config::Backend;
 use crate::db::session_repo;
 use crate::state::AppState;
@@ -15,12 +15,12 @@ use crate::terminal::ws_handler;
 /// GET /api/sessions/:id/terminal — upgrade to WebSocket for terminal access
 pub async fn terminal_upgrade(
     State(state): State<AppState>,
-    Extension(identity): Extension<Identity>,
+    Extension(principal): Extension<Principal>,
     Path(id): Path<Uuid>,
     ws: WebSocketUpgrade,
 ) -> impl IntoResponse {
     // Verify session belongs to user and is running
-    let session = match session_repo::get_session_for_user(&state.db, id, identity.user_id).await {
+    let session = match session_repo::get_session_for_user(&state.db, id, principal.user_id).await {
         Ok(Some(s)) => s,
         Ok(None) => return (StatusCode::NOT_FOUND, "session not found").into_response(),
         Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, "failed").into_response(),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,10 +7,19 @@ import SessionDetail from './pages/SessionDetail';
 import Settings from './pages/Settings';
 import Billing from './pages/Billing';
 import Navbar from './components/Navbar';
+import {
+  clearSession,
+  consumeOAuthCallbackSession,
+  getAccessToken,
+  getStoredUser,
+  setAccessToken,
+  setStoredUser,
+  type SessionUser,
+} from './auth/session';
 
 interface AuthContextType {
   token: string | null;
-  user: { id: string; email: string; username: string; is_admin: boolean } | null;
+  user: SessionUser | null;
   login: (token: string, user: AuthContextType['user']) => void;
   logout: () => void;
 }
@@ -33,29 +42,18 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
-  const [token, setToken] = useState<string | null>(localStorage.getItem('token'));
-  const [user, setUser] = useState<AuthContextType['user']>(() => {
-    const saved = localStorage.getItem('user');
-    return saved ? JSON.parse(saved) : null;
-  });
+  const [token, setToken] = useState<string | null>(() => getAccessToken());
+  const [user, setUser] = useState<AuthContextType['user']>(() => getStoredUser());
 
   // Handle OAuth callback token from URL fragment
   useEffect(() => {
-    const hash = window.location.hash;
-    if (hash.includes('token=')) {
-      const params = new URLSearchParams(hash.split('?')[1]);
-      const callbackToken = params.get('token');
-      if (callbackToken) {
-        setToken(callbackToken);
-        localStorage.setItem('token', callbackToken);
-        // Decode JWT to get user info
-        try {
-          const payload = JSON.parse(atob(callbackToken.split('.')[1]));
-          const u = { id: payload.sub, email: payload.email, username: payload.username, is_admin: payload.admin };
-          setUser(u);
-          localStorage.setItem('user', JSON.stringify(u));
-        } catch { /* ignore */ }
-        window.location.hash = '';
+    const callbackSession = consumeOAuthCallbackSession();
+    if (callbackSession) {
+      setToken(callbackSession.token);
+      setAccessToken(callbackSession.token);
+      if (callbackSession.user) {
+        setUser(callbackSession.user);
+        setStoredUser(callbackSession.user);
       }
     }
   }, []);
@@ -63,15 +61,14 @@ export default function App() {
   const login = (newToken: string, newUser: AuthContextType['user']) => {
     setToken(newToken);
     setUser(newUser);
-    localStorage.setItem('token', newToken);
-    if (newUser) localStorage.setItem('user', JSON.stringify(newUser));
+    setAccessToken(newToken);
+    if (newUser) setStoredUser(newUser);
   };
 
   const logout = () => {
     setToken(null);
     setUser(null);
-    localStorage.removeItem('token');
-    localStorage.removeItem('user');
+    clearSession();
   };
 
   return (

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,8 @@
-import { clearSession, getAccessToken } from '../auth/session';
+import {
+  clearSession,
+  getAccessToken,
+  type SessionUser,
+} from '../auth/session';
 
 const API_BASE = '/api';
 
@@ -32,7 +36,7 @@ export async function request<T>(path: string, options: RequestInit = {}): Promi
 // Auth
 export interface AuthResponse {
   token: string;
-  user: { id: string; email: string; username: string; is_admin: boolean };
+  user: SessionUser;
 }
 
 export interface Provider {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,11 +1,9 @@
+import { clearSession, getAccessToken } from '../auth/session';
+
 const API_BASE = '/api';
 
-function getToken(): string | null {
-  return localStorage.getItem('token');
-}
-
-async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const token = getToken();
+export async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const token = getAccessToken();
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     ...(options.headers as Record<string, string> || {}),
@@ -17,8 +15,7 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   const resp = await fetch(`${API_BASE}${path}`, { ...options, headers });
 
   if (resp.status === 401) {
-    localStorage.removeItem('token');
-    localStorage.removeItem('user');
+    clearSession();
     window.location.href = '/login';
     throw new Error('Unauthorized');
   }
@@ -146,9 +143,9 @@ export const users = {
   me: () => request<UserProfile>('/users/me'),
 };
 
-// WebSocket terminal URL (passes JWT as query param since browser WS API can't set headers)
+// WebSocket terminal URL (passes current access token as query param since browser WS API can't set headers)
 export function terminalWsUrl(sessionId: string): string {
   const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  const token = getToken();
+  const token = getAccessToken();
   return `${proto}//${window.location.host}/api/sessions/${sessionId}/terminal?token=${token}`;
 }

--- a/frontend/src/auth/session.ts
+++ b/frontend/src/auth/session.ts
@@ -1,0 +1,67 @@
+export interface SessionUser {
+  id: string;
+  email: string;
+  username: string;
+  is_admin: boolean;
+}
+
+const TOKEN_KEY = 'token';
+const USER_KEY = 'user';
+
+export function getAccessToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setAccessToken(token: string): void {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function getStoredUser(): SessionUser | null {
+  const saved = localStorage.getItem(USER_KEY);
+  if (!saved) return null;
+
+  try {
+    return JSON.parse(saved) as SessionUser;
+  } catch {
+    return null;
+  }
+}
+
+export function setStoredUser(user: SessionUser): void {
+  localStorage.setItem(USER_KEY, JSON.stringify(user));
+}
+
+export function clearSession(): void {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USER_KEY);
+}
+
+function decodeLegacyJwtUser(token: string): SessionUser | null {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return {
+      id: payload.sub,
+      email: payload.email,
+      username: payload.username,
+      is_admin: payload.admin,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function consumeOAuthCallbackSession(): { token: string; user: SessionUser | null } | null {
+  const hash = window.location.hash;
+  if (!hash.includes('token=')) return null;
+
+  const query = hash.split('?')[1];
+  if (!query) return null;
+
+  const params = new URLSearchParams(query);
+  const token = params.get('token');
+  if (!token) return null;
+
+  const user = decodeLegacyJwtUser(token);
+  window.location.hash = '';
+  return { token, user };
+}

--- a/frontend/src/auth/session.ts
+++ b/frontend/src/auth/session.ts
@@ -37,6 +37,8 @@ export function clearSession(): void {
 }
 
 function decodeLegacyJwtUser(token: string): SessionUser | null {
+  // TODO(auth-boundary): remove client-side JWT decoding for OAuth callback handling
+  // once the frontend can hydrate user state via a backend-owned user/session response.
   try {
     const payload = JSON.parse(atob(token.split('.')[1]));
     return {

--- a/frontend/src/pages/Billing.tsx
+++ b/frontend/src/pages/Billing.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { request } from '../api/client';
 
 interface UsageSummary {
   total_gpu_seconds: number;
@@ -17,19 +18,11 @@ interface UsageRecord {
 }
 
 async function fetchSummary(): Promise<UsageSummary> {
-  const token = localStorage.getItem('token');
-  const resp = await fetch('/api/billing/summary', {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  return resp.json();
+  return request<UsageSummary>('/billing/summary');
 }
 
 async function fetchUsage(): Promise<UsageRecord[]> {
-  const token = localStorage.getItem('token');
-  const resp = await fetch('/api/billing/usage', {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  return resp.json();
+  return request<UsageRecord[]>('/billing/usage');
 }
 
 export default function Billing() {


### PR DESCRIPTION
COmmit-1: Backend auth boundary
- Introduce a provider-agnostic Principal for authenticated backend callers.
- Replace JWT-specific Identity usage in protected middleware and route handlers with Principal.
- Keep JWT parsing and verification at the auth edge 
- Add backend tests for JWT-to-Principal mapping and middleware-based enforcement.

Commit-2: Frontend session boundary
- Add a shared session module for token storage, session clearing, and OAuth callback handling.
- Remove direct JWT parsing and token access from frontend code.
- Refactor the API client and billing page to use the session boundary.