### PR TITLE
Add Auth and session-state regression tests.

### DIFF
--- a/crates/spur-cloud-api/src/auth/oidc_common.rs
+++ b/crates/spur-cloud-api/src/auth/oidc_common.rs
@@ -115,3 +115,52 @@ pub fn validate_state(headers: &HeaderMap, state: Option<&str>) -> Result<(), &'
         None => Err("missing oauth_state cookie"),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::validate_state;
+    use axum::http::{HeaderMap, HeaderValue};
+
+    fn headers_with_cookie(cookie: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("cookie", HeaderValue::from_str(cookie).unwrap());
+        headers
+    }
+
+    #[test]
+    fn validate_state_accepts_matching_cookie_and_state() {
+        let headers = headers_with_cookie("oauth_state=abc123");
+
+        assert_eq!(validate_state(&headers, Some("abc123")), Ok(()));
+    }
+
+    #[test]
+    fn validate_state_rejects_missing_state_parameter() {
+        let headers = headers_with_cookie("oauth_state=abc123");
+
+        assert_eq!(
+            validate_state(&headers, None),
+            Err("missing state parameter")
+        );
+    }
+
+    #[test]
+    fn validate_state_rejects_missing_cookie() {
+        let headers = HeaderMap::new();
+
+        assert_eq!(
+            validate_state(&headers, Some("abc123")),
+            Err("missing oauth_state cookie")
+        );
+    }
+
+    #[test]
+    fn validate_state_rejects_mismatched_state() {
+        let headers = headers_with_cookie("oauth_state=abc123");
+
+        assert_eq!(
+            validate_state(&headers, Some("wrong")),
+            Err("state parameter mismatch")
+        );
+    }
+}

--- a/crates/spur-cloud-common/src/session_types.rs
+++ b/crates/spur-cloud-common/src/session_types.rs
@@ -82,3 +82,42 @@ fn default_gpu_count() -> i32 {
 fn default_time_limit() -> i32 {
     240
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SessionState;
+
+    #[test]
+    fn session_state_round_trips_through_strings() {
+        let cases = [
+            (SessionState::Creating, "creating"),
+            (SessionState::Pending, "pending"),
+            (SessionState::Running, "running"),
+            (SessionState::Stopping, "stopping"),
+            (SessionState::Completed, "completed"),
+            (SessionState::Failed, "failed"),
+            (SessionState::Cancelled, "cancelled"),
+        ];
+
+        for (state, raw) in cases {
+            assert_eq!(state.as_str(), raw);
+            assert_eq!(SessionState::from_str(raw), state);
+        }
+    }
+
+    #[test]
+    fn session_state_unknown_string_maps_to_failed() {
+        assert_eq!(SessionState::from_str("unknown"), SessionState::Failed);
+    }
+
+    #[test]
+    fn session_state_terminal_flag_matches_terminal_states() {
+        assert!(!SessionState::Creating.is_terminal());
+        assert!(!SessionState::Pending.is_terminal());
+        assert!(!SessionState::Running.is_terminal());
+        assert!(!SessionState::Stopping.is_terminal());
+        assert!(SessionState::Completed.is_terminal());
+        assert!(SessionState::Failed.is_terminal());
+        assert!(SessionState::Cancelled.is_terminal());
+    }
+}


### PR DESCRIPTION
Regression tests for OAuth state and SessionState
-  validate_state() coverage for matching, missing, and mismatched OAuth state cases
-  SessionState tests for string mapping, terminal-state classification, and unknown fallback behavior