### PR TITLE
Add error details to failed sessions (#12)

### DIFF
--- a/crates/spur-cloud-api/src/db/migrations.rs
+++ b/crates/spur-cloud-api/src/db/migrations.rs
@@ -86,6 +86,11 @@ pub async fn run_migrations(pool: &PgPool) -> anyhow::Result<()> {
     .execute(pool)
     .await?;
 
+    // Issue #12: Add error_message column for failed session diagnostics
+    sqlx::query("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS error_message TEXT")
+        .execute(pool)
+        .await?;
+
     info!("database migrations complete");
     Ok(())
 }

--- a/crates/spur-cloud-api/src/db/session_repo.rs
+++ b/crates/spur-cloud-api/src/db/session_repo.rs
@@ -151,3 +151,20 @@ pub async fn update_session_ended(pool: &PgPool, id: Uuid, final_state: &str) ->
         .await?;
     Ok(())
 }
+
+/// Update session state to failed with an error message.
+pub async fn update_session_failed(
+    pool: &PgPool,
+    id: Uuid,
+    error_message: &str,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "UPDATE sessions SET state = 'failed', ended_at = $2, error_message = $3 WHERE id = $1",
+    )
+    .bind(id)
+    .bind(Utc::now())
+    .bind(error_message)
+    .execute(pool)
+    .await?;
+    Ok(())
+}

--- a/crates/spur-cloud-api/src/main.rs
+++ b/crates/spur-cloud-api/src/main.rs
@@ -145,12 +145,19 @@ async fn session_sync_loop(state: AppState) {
             let job = match spur_client::get_job(&mut spur, job_id).await {
                 Ok(Some(j)) => j,
                 Ok(None) => {
-                    // Job gone from spur — mark failed
-                    let _ = db::session_repo::update_session_ended(&state.db, session.id, "failed")
-                        .await;
+                    // Job gone from spur — mark failed with error
+                    let _ = db::session_repo::update_session_failed(
+                        &state.db,
+                        session.id,
+                        "Job not found in Spur scheduler (may have been cancelled externally)",
+                    )
+                    .await;
                     continue;
                 }
-                Err(_) => continue,
+                Err(e) => {
+                    warn!(session = %session.id, "failed to query spur: {e}");
+                    continue;
+                }
             };
 
             // Map Spur job state to session state

--- a/crates/spur-cloud-api/src/models/session.rs
+++ b/crates/spur-cloud-api/src/models/session.rs
@@ -24,6 +24,7 @@ pub struct Session {
     pub ended_at: Option<DateTime<Utc>>,
     pub node_name: Option<String>,
     pub pod_name: Option<String>,
+    pub error_message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -43,6 +44,7 @@ pub struct SessionDetail {
     pub started_at: Option<DateTime<Utc>>,
     pub ended_at: Option<DateTime<Utc>>,
     pub node_name: Option<String>,
+    pub error_message: Option<String>,
 }
 
 impl From<Session> for SessionDetail {
@@ -63,6 +65,7 @@ impl From<Session> for SessionDetail {
             started_at: s.started_at,
             ended_at: s.ended_at,
             node_name: s.node_name,
+            error_message: s.error_message,
         }
     }
 }

--- a/crates/spur-cloud-api/src/routes/sessions.rs
+++ b/crates/spur-cloud-api/src/routes/sessions.rs
@@ -113,9 +113,10 @@ pub async fn create_session(
             (StatusCode::CREATED, Json(detail)).into_response()
         }
         Err(e) => {
-            error!("spur submission failed: {e}");
-            let _ = session_repo::update_session_state(&state.db, session.id, "failed").await;
-            (StatusCode::BAD_GATEWAY, "job submission to spur failed").into_response()
+            let err_msg = format!("Spur submission failed: {e}");
+            error!("{err_msg}");
+            let _ = session_repo::update_session_failed(&state.db, session.id, &err_msg).await;
+            (StatusCode::BAD_GATEWAY, err_msg).into_response()
         }
     }
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -76,6 +76,7 @@ export interface Session {
   started_at: string | null;
   ended_at: string | null;
   node_name: string | null;
+  error_message: string | null;
 }
 
 export interface CreateSession {

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -91,6 +91,14 @@ export default function SessionDetail() {
         </div>
       </div>
 
+      {/* Error Message */}
+      {session.error_message && (
+        <div className="bg-red-950 border border-red-800 rounded-lg p-6 mb-6">
+          <h2 className="text-lg font-semibold text-red-400 mb-2">Error</h2>
+          <pre className="text-red-300 text-sm font-mono whitespace-pre-wrap">{session.error_message}</pre>
+        </div>
+      )}
+
       {/* SSH Access */}
       {sshCommand && isRunning && (
         <div className="bg-gray-900 border border-gray-800 rounded-lg p-6 mb-6">


### PR DESCRIPTION
## Summary
Closes #12 — failed sessions now show detailed error messages.

## Changes
- Added `error_message` column to sessions table
- Store detailed errors on Spur submission failure and job disappearance
- Show error in red banner on session detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)