### PR TITLE
Fix GPU capacity not updated after cancel (#13)

### DIFF
--- a/crates/spur-cloud-api/src/routes/sessions.rs
+++ b/crates/spur-cloud-api/src/routes/sessions.rs
@@ -187,7 +187,10 @@ pub async fn delete_session(
         }
     }
 
-    let _ = session_repo::update_session_ended(&state.db, id, "cancelled").await;
-    info!(session_id = %id, "session cancelled");
+    // Issue #13: Set state to "stopping" instead of "cancelled" immediately.
+    // The session_sync_loop will detect the terminal state from Spur and
+    // transition to "cancelled" once GPUs are actually released.
+    let _ = session_repo::update_session_state(&state.db, id, "stopping").await;
+    info!(session_id = %id, "session stopping (waiting for Spur confirmation)");
     StatusCode::NO_CONTENT.into_response()
 }


### PR DESCRIPTION
## Summary
Closes #13 — GPU capacity now updates correctly after session cancellation.

## Changes
Changed `delete_session` to set state to "stopping" instead of immediately "cancelled". The `session_sync_loop` waits for Spur to confirm the job is actually cancelled before transitioning to "cancelled" and releasing capacity.

## Before/After
**Before:** Cancel → state immediately "cancelled" → dashboard shows wrong GPU count (Spur still freeing)
**After:** Cancel → state "stopping" → Spur confirms → state "cancelled" → dashboard accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)