### PR TITLE
Fix web terminal hangs on macOS (#10)

### DIFF
--- a/crates/spur-cloud-api/src/terminal/ws_handler.rs
+++ b/crates/spur-cloud-api/src/terminal/ws_handler.rs
@@ -85,7 +85,7 @@ pub async fn handle_terminal(
         }
     });
 
-    // Task 2: pod stdout → WebSocket
+    // Task 2: pod stdout → WebSocket (with send timeout to prevent hangs — Issue #10)
     let stdout_handle = tokio::spawn(async move {
         let mut buf = [0u8; 4096];
         loop {
@@ -93,8 +93,14 @@ pub async fn handle_terminal(
                 Ok(0) => break,
                 Ok(n) => {
                     let data = String::from_utf8_lossy(&buf[..n]).to_string();
-                    if ws_sink.send(Message::Text(data)).await.is_err() {
-                        break;
+                    match tokio::time::timeout(
+                        std::time::Duration::from_secs(5),
+                        ws_sink.send(Message::Text(data)),
+                    )
+                    .await
+                    {
+                        Ok(Ok(_)) => {}
+                        _ => break, // Send timeout or error — client likely disconnected
                     }
                 }
                 Err(_) => break,
@@ -230,7 +236,7 @@ pub async fn handle_terminal_spur(
         }
     });
 
-    // Task 2: gRPC stdout → WebSocket
+    // Task 2: gRPC stdout → WebSocket (with send timeout — Issue #10)
     let stdout_handle = tokio::spawn(async move {
         loop {
             match out_stream.message().await {
@@ -240,7 +246,12 @@ pub async fn handle_terminal_spur(
                     }
                     if !chunk.data.is_empty() {
                         let text = String::from_utf8_lossy(&chunk.data).to_string();
-                        if ws_sink.send(Message::Text(text)).await.is_err() {
+                        let send_result = tokio::time::timeout(
+                            std::time::Duration::from_secs(5),
+                            ws_sink.send(Message::Text(text)),
+                        )
+                        .await;
+                        if !matches!(send_result, Ok(Ok(_))) {
                             break;
                         }
                     }

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -26,6 +26,9 @@ export default function Terminal({ wsUrl }: Props) {
       fontFamily: '"JetBrains Mono", "Fira Code", monospace',
       fontSize: 14,
       cursorBlink: true,
+      // Issue #10: explicit buffer/scroll config for cross-platform compatibility
+      scrollback: 5000,
+      convertEol: true,
     });
     xtermRef.current = term;
 
@@ -38,6 +41,7 @@ export default function Terminal({ wsUrl }: Props) {
 
     // Connect WebSocket
     const ws = new WebSocket(wsUrl);
+    ws.binaryType = 'arraybuffer'; // Handle binary data properly
     wsRef.current = ws;
 
     ws.onopen = () => {
@@ -45,11 +49,20 @@ export default function Terminal({ wsUrl }: Props) {
     };
 
     ws.onmessage = (event) => {
-      term.write(event.data);
+      if (typeof event.data === 'string') {
+        term.write(event.data);
+      } else {
+        // Handle binary data (ArrayBuffer)
+        term.write(new Uint8Array(event.data));
+      }
     };
 
-    ws.onclose = () => {
-      term.writeln('\r\n\x1b[31mConnection closed.\x1b[0m');
+    ws.onclose = (event) => {
+      if (event.wasClean) {
+        term.writeln('\r\n\x1b[33mSession ended.\x1b[0m');
+      } else {
+        term.writeln('\r\n\x1b[31mConnection lost.\x1b[0m');
+      }
     };
 
     ws.onerror = () => {
@@ -63,6 +76,15 @@ export default function Terminal({ wsUrl }: Props) {
       }
     });
 
+    // Issue #10: WebSocket keepalive ping every 30s to prevent idle timeout
+    const pingInterval = setInterval(() => {
+      if (ws.readyState === WebSocket.OPEN) {
+        // Send empty ping to keep connection alive
+        // Some proxies (nginx) close idle WebSocket connections
+        ws.send('');
+      }
+    }, 30000);
+
     // Handle resize
     const resizeObserver = new ResizeObserver(() => {
       fitAddon.fit();
@@ -70,6 +92,7 @@ export default function Terminal({ wsUrl }: Props) {
     resizeObserver.observe(termRef.current);
 
     return () => {
+      clearInterval(pingInterval);
       resizeObserver.disconnect();
       ws.close();
       term.dispose();


### PR DESCRIPTION
## Summary
Closes #10 — web terminal reliability improvements for macOS.

## Changes
**Frontend:**
- 30s WebSocket keepalive ping (prevents idle timeout from proxies)
- Binary data handling (`binaryType='arraybuffer'`)
- `scrollback=5000`, `convertEol=true` for cross-platform compat

**Backend:**
- 5s send timeout on WebSocket writes (both K8s and bare-metal handlers)
- Prevents indefinite blocking when client becomes unresponsive

## Root cause
macOS browsers aggressively background tabs, causing WebSocket connections to go idle. Nginx and other proxies then close the connection (default 60s idle timeout). The keepalive ping prevents this. The send timeout prevents the server from blocking indefinitely if the client is truly gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)