### PR TITLE
Add K8s SpurJob CRD creation for session dispatch (#113)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,6 +2803,7 @@ dependencies = [
  "prost-types",
  "rand 0.8.5",
  "reqwest",
+ "schemars",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 thiserror = "2"
 anyhow = "1"
 
+# K8s CRD schema
+schemars = "0.8"
+
 # Misc
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/spur-cloud-api/Cargo.toml
+++ b/crates/spur-cloud-api/Cargo.toml
@@ -31,6 +31,7 @@ sqlx.workspace = true
 
 kube.workspace = true
 k8s-openapi.workspace = true
+schemars.workspace = true
 
 jsonwebtoken.workspace = true
 argon2.workspace = true

--- a/crates/spur-cloud-api/src/routes/sessions.rs
+++ b/crates/spur-cloud-api/src/routes/sessions.rs
@@ -113,37 +113,78 @@ pub async fn create_session(
         None
     };
 
-    // Submit to Spur
-    let bare_metal = state.config.server.backend == Backend::BareMetal;
-    let mut spur = state.spur.clone();
-    match spur_client::submit_session(
-        &mut spur,
-        &req.name,
-        &req.gpu_type,
-        req.gpu_count,
-        &req.container_image,
-        req.partition.as_deref(),
-        req.ssh_enabled,
-        req.time_limit_min,
-        &session.id.to_string(),
-        &ssh_keys_str,
-        ssh_port,
-        bare_metal,
-    )
-    .await
-    {
-        Ok(job_id) => {
-            let _ =
-                session_repo::update_session_spur_job(&state.db, session.id, job_id as i32).await;
-            info!(session_id = %session.id, job_id, "session submitted");
-            let detail: SessionDetail = session.into();
-            (StatusCode::CREATED, Json(detail)).into_response()
+    // Submit to Spur — different paths for K8s and bare-metal
+    match state.config.server.backend {
+        Backend::K8s => {
+            // K8s mode: create a SpurJob CRD. The spur-k8s operator watches
+            // for these and handles submission to spurctld + pod creation.
+            let kube_client = state
+                .kube
+                .as_ref()
+                .expect("k8s backend requires kube client");
+            let ns = &state.config.server.session_namespace;
+            match spur_client::create_spurjob_crd(
+                kube_client,
+                ns,
+                &session.id.to_string(),
+                &req.name,
+                &req.gpu_type,
+                req.gpu_count,
+                &req.container_image,
+                req.time_limit_min,
+                req.ssh_enabled,
+            )
+            .await
+            {
+                Ok(crd_name) => {
+                    info!(session_id = %session.id, crd_name, "SpurJob CRD created");
+                    let detail: SessionDetail = session.into();
+                    (StatusCode::CREATED, Json(detail)).into_response()
+                }
+                Err(e) => {
+                    let err_msg = format!("SpurJob CRD creation failed: {e}");
+                    error!("{err_msg}");
+                    let _ =
+                        session_repo::update_session_failed(&state.db, session.id, &err_msg).await;
+                    (StatusCode::BAD_GATEWAY, err_msg).into_response()
+                }
+            }
         }
-        Err(e) => {
-            let err_msg = format!("Spur submission failed: {e}");
-            error!("{err_msg}");
-            let _ = session_repo::update_session_failed(&state.db, session.id, &err_msg).await;
-            (StatusCode::BAD_GATEWAY, err_msg).into_response()
+        Backend::BareMetal => {
+            // Bare-metal mode: submit directly to spurctld via gRPC
+            let mut spur = state.spur.clone();
+            match spur_client::submit_session(
+                &mut spur,
+                &req.name,
+                &req.gpu_type,
+                req.gpu_count,
+                &req.container_image,
+                req.partition.as_deref(),
+                req.ssh_enabled,
+                req.time_limit_min,
+                &session.id.to_string(),
+                &ssh_keys_str,
+                ssh_port,
+                true, // bare_metal
+            )
+            .await
+            {
+                Ok(job_id) => {
+                    let _ =
+                        session_repo::update_session_spur_job(&state.db, session.id, job_id as i32)
+                            .await;
+                    info!(session_id = %session.id, job_id, "session submitted via gRPC");
+                    let detail: SessionDetail = session.into();
+                    (StatusCode::CREATED, Json(detail)).into_response()
+                }
+                Err(e) => {
+                    let err_msg = format!("Spur submission failed: {e}");
+                    error!("{err_msg}");
+                    let _ =
+                        session_repo::update_session_failed(&state.db, session.id, &err_msg).await;
+                    (StatusCode::BAD_GATEWAY, err_msg).into_response()
+                }
+            }
         }
     }
 }
@@ -207,18 +248,31 @@ pub async fn delete_session(
         }
     };
 
-    // Cancel in Spur if job exists
-    if let Some(job_id) = session.spur_job_id {
-        let mut spur = state.spur.clone();
-        if let Err(e) = spur_client::cancel_job(&mut spur, job_id as u32).await {
-            error!("spur cancel failed: {e}");
+    // Cancel in Spur
+    match state.config.server.backend {
+        Backend::K8s => {
+            // K8s: delete the SpurJob CRD — operator handles pod cleanup
+            if let Some(kube_client) = state.kube.as_ref() {
+                let ns = &state.config.server.session_namespace;
+                if let Err(e) =
+                    spur_client::delete_spurjob_crd(kube_client, ns, &id.to_string()).await
+                {
+                    error!("SpurJob CRD deletion failed: {e}");
+                }
+            }
+        }
+        Backend::BareMetal => {
+            // Bare-metal: cancel via gRPC
+            if let Some(job_id) = session.spur_job_id {
+                let mut spur = state.spur.clone();
+                if let Err(e) = spur_client::cancel_job(&mut spur, job_id as u32).await {
+                    error!("spur cancel failed: {e}");
+                }
+            }
         }
     }
 
-    // Issue #13: Set state to "stopping" instead of "cancelled" immediately.
-    // The session_sync_loop will detect the terminal state from Spur and
-    // transition to "cancelled" once GPUs are actually released.
     let _ = session_repo::update_session_state(&state.db, id, "stopping").await;
-    info!(session_id = %id, "session stopping (waiting for Spur confirmation)");
+    info!(session_id = %id, "session stopping");
     StatusCode::NO_CONTENT.into_response()
 }

--- a/crates/spur-cloud-api/src/spur_client.rs
+++ b/crates/spur-cloud-api/src/spur_client.rs
@@ -1,10 +1,150 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
+use kube::api::{Api, DeleteParams, PostParams};
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use tonic::transport::Channel;
-use tracing::debug;
+use tracing::{debug, info};
 
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::*;
+
+// ── SpurJob CRD (minimal definition matching spur-k8s operator) ──
+
+/// GPU configuration for a SpurJob.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GpuSpec {
+    pub count: u32,
+    #[serde(default)]
+    pub gpu_type: Option<String>,
+}
+
+impl Default for GpuSpec {
+    fn default() -> Self {
+        Self {
+            count: 0,
+            gpu_type: None,
+        }
+    }
+}
+
+/// SpurJob CRD spec — matches the operator's SpurJobSpec.
+#[derive(CustomResource, Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[kube(group = "spur.ai", version = "v1alpha1", kind = "SpurJob", namespaced)]
+#[serde(rename_all = "camelCase")]
+pub struct SpurJobSpec {
+    pub name: String,
+    pub image: String,
+    #[serde(default)]
+    pub gpus: GpuSpec,
+    #[serde(default = "default_one")]
+    pub num_nodes: u32,
+    #[serde(default = "default_one")]
+    pub tasks_per_node: u32,
+    #[serde(default = "default_one")]
+    pub cpus_per_task: u32,
+    #[serde(default)]
+    pub time_limit: Option<String>,
+    #[serde(default)]
+    pub command: Vec<String>,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    #[serde(default)]
+    pub host_network: bool,
+    #[serde(default)]
+    pub privileged: bool,
+}
+
+fn default_one() -> u32 {
+    1
+}
+
+/// Create a SpurJob CRD in Kubernetes for a spur-cloud session.
+///
+/// Used when `backend = "k8s"`. The spur-k8s operator watches for SpurJob
+/// resources, submits them to spurctld, and creates pods.
+pub async fn create_spurjob_crd(
+    kube_client: &kube::Client,
+    namespace: &str,
+    session_id: &str,
+    name: &str,
+    gpu_type: &str,
+    gpu_count: i32,
+    container_image: &str,
+    time_limit_min: i32,
+    ssh_enabled: bool,
+) -> anyhow::Result<String> {
+    let api: Api<SpurJob> = Api::namespaced(kube_client.clone(), namespace);
+
+    let job_name = format!("session-{}", &session_id[..8]);
+
+    let mut labels = BTreeMap::new();
+    labels.insert("spur.ai/session-id".to_string(), session_id.to_string());
+    labels.insert("spur.ai/managed-by".to_string(), "spur-cloud".to_string());
+
+    let mut env = HashMap::new();
+    env.insert("GPUAAS_SESSION_ID".to_string(), session_id.to_string());
+
+    let spurjob = SpurJob::new(
+        &job_name,
+        SpurJobSpec {
+            name: name.to_string(),
+            image: container_image.to_string(),
+            gpus: GpuSpec {
+                count: gpu_count as u32,
+                gpu_type: Some(gpu_type.to_string()),
+            },
+            num_nodes: 1,
+            tasks_per_node: 1,
+            cpus_per_task: 8,
+            time_limit: Some(format!("{}m", time_limit_min)),
+            command: vec![],
+            args: vec![],
+            env,
+            host_network: false,
+            privileged: false,
+        },
+    );
+
+    let mut spurjob = spurjob;
+    spurjob.metadata.labels = Some(labels);
+    spurjob.metadata.namespace = Some(namespace.to_string());
+
+    let created = api.create(&PostParams::default(), &spurjob).await?;
+    let crd_name = created.metadata.name.unwrap_or_default();
+
+    info!(
+        session_id,
+        crd_name = %crd_name,
+        namespace,
+        "SpurJob CRD created for K8s session"
+    );
+
+    Ok(crd_name)
+}
+
+/// Delete a SpurJob CRD (on session cancellation).
+pub async fn delete_spurjob_crd(
+    kube_client: &kube::Client,
+    namespace: &str,
+    session_id: &str,
+) -> anyhow::Result<()> {
+    let api: Api<SpurJob> = Api::namespaced(kube_client.clone(), namespace);
+    let job_name = format!("session-{}", &session_id[..8]);
+
+    match api.delete(&job_name, &DeleteParams::default()).await {
+        Ok(_) => {
+            info!(session_id, "SpurJob CRD deleted");
+            Ok(())
+        }
+        Err(kube::Error::Api(e)) if e.code == 404 => Ok(()), // already gone
+        Err(e) => Err(e.into()),
+    }
+}
 
 /// Submit a GPU session as a Spur job. Returns the assigned job ID.
 ///


### PR DESCRIPTION
## Summary
Fixes the K8s session dispatch gap (ROCm/spur#113). Closes #21, #24, #25.

## Problem
When `backend = "k8s"`, spur-cloud submitted sessions via gRPC to spurctld. The K8s operator's VirtualAgent then tried to find a SpurJob CRD to determine the pod namespace — but no CRD existed, so `resolve_namespace()` failed and no pod was ever created.

## Fix
When `backend = "k8s"`, spur-cloud now creates a SpurJob CRD via the K8s API:
```
spur-cloud → SpurJob CRD (in spur-sessions namespace)
  → operator watches → submits to spurctld
  → scheduler dispatches to VirtualAgent
  → resolve_namespace() finds the CRD → creates Pod
```

Bare-metal path is unchanged (gRPC → spurctld → spurd).

## Changes
- New `SpurJobSpec` CRD type in `spur_client.rs` (matches operator's definition)
- `create_spurjob_crd()` / `delete_spurjob_crd()` functions
- `create_session()` branches on backend: K8s creates CRD, bare-metal uses gRPC
- `delete_session()` branches: K8s deletes CRD, bare-metal cancels via gRPC

## Test plan
- [x] Compiles clean
- [ ] K8s: create session → SpurJob CRD appears → operator creates pod
- [ ] K8s: cancel session → SpurJob CRD deleted → pod cleaned up
- [x] Bare-metal: unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)