### PR TITLE
k8s: add spurjobs RBAC permissions to spur-cloud ClusterRole

### DIFF
--- a/deploy/k8s/gpuaas-api.yaml
+++ b/deploy/k8s/gpuaas-api.yaml
@@ -84,6 +84,10 @@ rules:
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "create", "delete"]
+  # For spurjob CRs
+  - apiGroups: ["spur.ai"]
+    resources: ["spurjobs"]
+    verbs: ["get", "list", "create", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Problem

The spur-cloud service account was missing permissions to create/patch/delete
SpurJob CRs in the spur namespace. This caused every session launch in K8s
mode to fail with a 403 Forbidden error before the operator could process
the job.

## Change

Added spur.ai API group rule to the ClusterRole in deploy/k8s/gpuaas-api.yaml:

  - apiGroups: ["spur.ai"]
    resources: ["spurjobs"]
    verbs: ["get", "list", "create", "patch", "delete"]

## Files Changed
- deploy/k8s/gpuaas-api.yaml