### PR TITLE
correct Cargo.lock COPY path and add touch to prevent dummy binary caching

### DIFF
--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/ap
 WORKDIR /build
 
 # Copy workspace manifests first for layer caching
-COPY spur-cloud/Cargo.toml Cargo.lock ./
+COPY spur-cloud/Cargo.toml spur-cloud/Cargo.lock ./
 COPY spur-cloud/crates/spur-cloud-api/Cargo.toml crates/spur-cloud-api/Cargo.toml
 COPY spur-cloud/crates/spur-cloud-common/Cargo.toml crates/spur-cloud-common/Cargo.toml
 

--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -27,6 +27,9 @@ RUN cargo build --release --bin spur-cloud-api 2>/dev/null || true
 # Copy actual source
 COPY spur-cloud/crates/ crates/
 
+# Force cargo to recompile by touching the source files
+RUN touch crates/spur-cloud-api/src/main.rs crates/spur-cloud-common/src/lib.rs
+
 # Build the binary
 RUN cargo build --release --bin spur-cloud-api
 


### PR DESCRIPTION
## Changes

### 1. Fix Cargo.lock COPY path (line 10)
When building from the parent directory context, Cargo.lock is located
at spur-cloud/Cargo.lock, not at the context root.

  Before: COPY spur-cloud/Cargo.toml Cargo.lock ./
  After:  COPY spur-cloud/Cargo.toml spur-cloud/Cargo.lock ./

### 2. Add touch before final cargo build
Forces cargo to recompile workspace binaries regardless of Docker layer
cache state, preventing the dummy 406KB binary from being shipped in the
runtime image.

  RUN touch crates/spur-cloud-api/src/main.rs \
            crates/spur-cloud-common/src/lib.rs

## Files Changed
- deploy/docker/Dockerfile.api