### PR TITLE
Fix K8s session sync: poll SpurJob CRD status (#30)

### DIFF
--- a/crates/spur-cloud-api/src/main.rs
+++ b/crates/spur-cloud-api/src/main.rs
@@ -138,7 +138,61 @@ async fn session_sync_loop(state: AppState) {
         for session in &active {
             let job_id = match session.spur_job_id {
                 Some(id) => id as u32,
-                None => continue,
+                None => {
+                    // K8s mode: session has no spur_job_id yet. Poll the SpurJob
+                    // CRD to see if the operator has assigned one.
+                    if state.config.server.backend == config::Backend::K8s {
+                        if let Some(kube_client) = state.kube.as_ref() {
+                            let ns = &state.config.server.session_namespace;
+                            let crd_name = format!("session-{}", &session.id.to_string()[..8]);
+                            let api: kube::Api<spur_client::SpurJob> =
+                                kube::Api::namespaced(kube_client.clone(), ns);
+                            if let Ok(spurjob) = api.get(&crd_name).await {
+                                if let Some(status) = &spurjob.status {
+                                    // Sync spur_job_id from CRD status
+                                    if let Some(id) = status.spur_job_id {
+                                        let _ = db::session_repo::update_session_spur_job(
+                                            &state.db, session.id, id as i32,
+                                        )
+                                        .await;
+                                    }
+
+                                    // Sync session state from CRD status
+                                    let node =
+                                        status.assigned_nodes.first().cloned().unwrap_or_default();
+                                    match status.state.as_str() {
+                                        "Running" if !node.is_empty() => {
+                                            let pod_name = format!("spur-job-{}", crd_name);
+                                            let _ = db::session_repo::update_session_running(
+                                                &state.db, session.id, &node, &pod_name,
+                                            )
+                                            .await;
+                                            info!(session = %session.id, node, "K8s session running");
+                                        }
+                                        "Completed" | "Failed" | "Cancelled" => {
+                                            let final_state = status.state.to_lowercase();
+                                            let _ = db::session_repo::update_session_ended(
+                                                &state.db,
+                                                session.id,
+                                                &final_state,
+                                            )
+                                            .await;
+                                            info!(session = %session.id, state = %final_state, "K8s session ended");
+                                        }
+                                        "Pending" => {
+                                            let _ = db::session_repo::update_session_state(
+                                                &state.db, session.id, "pending",
+                                            )
+                                            .await;
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    continue;
+                }
             };
 
             let mut spur = state.spur.clone();

--- a/crates/spur-cloud-api/src/spur_client.rs
+++ b/crates/spur-cloud-api/src/spur_client.rs
@@ -30,9 +30,27 @@ impl Default for GpuSpec {
     }
 }
 
+/// SpurJob status — matches the operator's SpurJobStatus.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SpurJobStatus {
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub spur_job_id: Option<u32>,
+    #[serde(default)]
+    pub assigned_nodes: Vec<String>,
+}
+
 /// SpurJob CRD spec — matches the operator's SpurJobSpec.
 #[derive(CustomResource, Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[kube(group = "spur.ai", version = "v1alpha1", kind = "SpurJob", namespaced)]
+#[kube(
+    group = "spur.ai",
+    version = "v1alpha1",
+    kind = "SpurJob",
+    namespaced,
+    status = "SpurJobStatus"
+)]
 #[serde(rename_all = "camelCase")]
 pub struct SpurJobSpec {
     pub name: String,


### PR DESCRIPTION
## Summary
Fixes #30 — K8s sessions no longer stuck in "creating".

## Problem
In K8s mode, sessions don't get a `spur_job_id` at creation (the operator assigns it later). The sync loop skipped sessions without a `spur_job_id`, leaving them in "creating" forever.

## Fix
For K8s sessions without `spur_job_id`, the sync loop now polls the SpurJob CRD status to sync:
- `spur_job_id` from `status.spurJobId`
- Session state from `status.state` (Pending → Running → Completed/Failed)
- Node assignment from `status.assignedNodes`

Added typed `SpurJobStatus` struct for clean status access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)