### PR TITLE
kube 0.97 upgrade, WebSocket terminal fix, pod lookup by label

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,12 +281,6 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -726,15 +720,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
-name = "fluent-uri"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,16 +923,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1401,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "2.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
+checksum = "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08"
 dependencies = [
  "jsonptr",
  "serde",
@@ -1413,26 +1388,23 @@ dependencies = [
 
 [[package]]
 name = "jsonpath-rust"
-version = "0.5.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
+checksum = "0c00ae348f9f8fd2d09f82a98ca381c60df9e0820d8d79fce43e649b4dc3128b"
 dependencies = [
- "lazy_static",
- "once_cell",
  "pest",
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "jsonptr"
-version = "0.4.7"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
+checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
 dependencies = [
- "fluent-uri",
  "serde",
  "serde_json",
 ]
@@ -1467,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efffeb3df0bd4ef3e5d65044573499c0e4889b988070b08c50b25b1329289a1f"
+checksum = "e5fd2596428f922f784ca43907c449f104d69055c811135684474143736c67ae"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1480,9 +1452,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf471ece8ff8d24735ce78dac4d091e9fcb8d74811aeb6b75de4d1c3f5de0f1"
+checksum = "d539b6493d162ae5ab691762be972b6a1c20f6d8ddafaae305c0e2111b589d99"
 dependencies = [
  "base64",
  "bytes",
@@ -1509,7 +1481,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
@@ -1520,9 +1492,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42346d30bb34d1d7adc5c549b691bce7aa3a1e60254e68fab7e2d7b26fe3d77"
+checksum = "98a87cc0046cf6b62cbb63ae1fbc366ee8ba29269f575289679473754ff5d7a7"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1533,14 +1505,14 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "kube-derive"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9364e04cc5e0482136c6ee8b7fb7551812da25802249f35b3def7aaa31e82ad"
+checksum = "65576922713e6154a89b5a8d2747adca15725b90fa64fc2b828774bf96d6acd8"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1551,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fbf1f6ffa98e65f1d2a9a69338bb60605d46be7edf00237784b89e62c9bd44"
+checksum = "4f348cc3e6c9be0ae17f300594bde541b667d10ab8934a119edd61ab5123c43e"
 dependencies = [
  "ahash",
  "async-broadcast",
@@ -1562,7 +1534,7 @@ dependencies = [
  "backoff",
  "educe",
  "futures",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
  "json-patch",
  "jsonptr",
  "k8s-openapi",
@@ -1571,7 +1543,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1610,7 +1582,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -2247,7 +2219,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2256,7 +2228,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2372,7 +2344,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2515,7 +2487,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -2528,7 +2500,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2940,7 +2912,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.11.0",
+ "bitflags",
  "byteorder",
  "bytes",
  "chrono",
@@ -2984,7 +2956,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.11.0",
+ "bitflags",
  "byteorder",
  "chrono",
  "crc",
@@ -3422,7 +3394,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "http",
  "http-body",
@@ -3440,7 +3412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "base64",
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -3804,7 +3776,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -4206,7 +4178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ toml = "0.8"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "uuid"] }
 
 # K8s (for kube exec terminal bridge)
-kube = { version = "0.96", features = ["runtime", "derive", "client", "ws"] }
+kube = { version = "0.97", features = ["runtime", "derive", "client", "ws"] }
 k8s-openapi = { version = "0.23", features = ["latest"] }
 
 # Auth

--- a/crates/spur-cloud-api/src/routes/ws.rs
+++ b/crates/spur-cloud-api/src/routes/ws.rs
@@ -4,6 +4,8 @@ use axum::{
     response::IntoResponse,
     Extension,
 };
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::{Api, ListParams};
 use uuid::Uuid;
 
 use crate::auth::principal::Principal;
@@ -32,8 +34,8 @@ pub async fn terminal_upgrade(
 
     match state.config.server.backend {
         Backend::K8s => {
-            let pod_name = match &session.pod_name {
-                Some(p) => p.clone(),
+            let job_id = match session.spur_job_id {
+                Some(id) => id,
                 None => return (StatusCode::BAD_REQUEST, "session pod not ready").into_response(),
             };
             let namespace = state.config.server.session_namespace.clone();
@@ -41,6 +43,33 @@ pub async fn terminal_upgrade(
                 .kube
                 .clone()
                 .expect("k8s backend requires kube client");
+
+            // Look up the actual running pod by label rather than the stored pod_name,
+            // because the agent appends a node suffix (e.g. spur-job-9-gpu-2) that
+            // the status watcher does not capture when it writes pod_name to the DB.
+            let pods: Api<Pod> = Api::namespaced(kube_client.clone(), &namespace);
+            let lp = ListParams::default()
+                .labels(&format!("spur.ai/job-id={}", job_id))
+                .limit(1);
+            let pod_name = match pods.list(&lp).await {
+                Ok(list) => {
+                    match list.items.into_iter().next().and_then(|p| p.metadata.name) {
+                        Some(name) => name,
+                        None => {
+                            return (
+                                StatusCode::SERVICE_UNAVAILABLE,
+                                "session pod not found in cluster",
+                            )
+                                .into_response();
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(session = %id, job_id, error = %e, "failed to look up pod by label");
+                    return (StatusCode::INTERNAL_SERVER_ERROR, "failed to query pod")
+                        .into_response();
+                }
+            };
 
             ws.on_upgrade(move |socket| {
                 ws_handler::handle_terminal(socket, kube_client, namespace, pod_name)

--- a/crates/spur-cloud-api/src/routes/ws.rs
+++ b/crates/spur-cloud-api/src/routes/ws.rs
@@ -52,18 +52,16 @@ pub async fn terminal_upgrade(
                 .labels(&format!("spur.ai/job-id={}", job_id))
                 .limit(1);
             let pod_name = match pods.list(&lp).await {
-                Ok(list) => {
-                    match list.items.into_iter().next().and_then(|p| p.metadata.name) {
-                        Some(name) => name,
-                        None => {
-                            return (
-                                StatusCode::SERVICE_UNAVAILABLE,
-                                "session pod not found in cluster",
-                            )
-                                .into_response();
-                        }
+                Ok(list) => match list.items.into_iter().next().and_then(|p| p.metadata.name) {
+                    Some(name) => name,
+                    None => {
+                        return (
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            "session pod not found in cluster",
+                        )
+                            .into_response();
                     }
-                }
+                },
                 Err(e) => {
                     tracing::error!(session = %id, job_id, error = %e, "failed to look up pod by label");
                     return (StatusCode::INTERNAL_SERVER_ERROR, "failed to query pod")

--- a/crates/spur-cloud-api/src/terminal/ws_handler.rs
+++ b/crates/spur-cloud-api/src/terminal/ws_handler.rs
@@ -27,7 +27,7 @@ pub async fn handle_terminal(
     let attach_params = AttachParams {
         stdin: true,
         stdout: true,
-        stderr: true,
+        stderr: false, // tty=true merges stderr into stdout; cannot have both true
         tty: true,
         container: None,
         max_stdin_buf_size: Some(1024),

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -10,6 +10,7 @@ data:
     [server]
     listen_addr = "0.0.0.0:8080"
     session_namespace = "spur-sessions"
+    backend = "k8s"
 
     [database]
     url = "postgresql://spur_cloud:CHANGEME@postgres:5432/spur_cloud"

--- a/deploy/k8s/gpuaas-api.yaml
+++ b/deploy/k8s/gpuaas-api.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: spur-cloud
       containers:
         - name: api
-          image: spur-cloud-api:latest
+          image: amdaccelcloud/spur-cloud-api:latest
           args:
             - --config=/etc/spur-cloud/spur-cloud.toml
           ports:
@@ -84,10 +84,10 @@ rules:
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "create", "delete"]
-  # For spurjob CRs
+  # For SpurJob CRDs
   - apiGroups: ["spur.ai"]
     resources: ["spurjobs"]
-    verbs: ["get", "list", "create", "patch", "delete"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -101,3 +101,31 @@ roleRef:
   kind: ClusterRole
   name: spur-cloud
   apiGroup: rbac.authorization.k8s.io
+---
+# NetworkPolicy: only the ingress-nginx controller and the frontend pod may reach the API.
+# External traffic always enters via the ingress controller on the control-plane.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: spur-cloud-api
+  namespace: spur-cloud
+spec:
+  podSelector:
+    matchLabels:
+      app: spur-cloud-api
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow from the ingress-nginx controller pod (for /api routes)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+    # Allow from the frontend pod (in-cluster API calls)
+    - from:
+        - podSelector:
+            matchLabels:
+              app: spur-cloud-frontend

--- a/deploy/k8s/gpuaas-frontend.yaml
+++ b/deploy/k8s/gpuaas-frontend.yaml
@@ -4,6 +4,7 @@ metadata:
   name: spur-cloud-frontend
   namespace: spur-cloud
 spec:
+  type: ClusterIP
   selector:
     app: spur-cloud-frontend
   ports:
@@ -28,7 +29,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: spur-cloud-frontend:latest
+          image: amdaccelcloud/spur-cloud-frontend:latest
           ports:
             - containerPort: 80
           resources:
@@ -39,6 +40,12 @@ spec:
               cpu: "500m"
               memory: "256Mi"
 ---
+# Ingress — handled by the nginx-ingress-controller running on the control-plane.
+# TLS terminates at the controller using the self-signed cert in spur-cloud-tls.
+# Generate the secret with: deploy/k8s/gen-tls-cert.sh
+#
+# To enable HTTPS from specific IPs or publicly, adjust the firewall/security group
+# on the control-plane node for ports 80 and 443. No changes needed here.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -48,10 +55,13 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    # HTTP is automatically redirected to HTTPS (set in ingress-controller ConfigMap)
 spec:
+  ingressClassName: nginx
+  tls:
+    - secretName: spur-cloud-tls
   rules:
-    - host: gpu.example.com  # Replace with actual domain
-      http:
+    - http:
         paths:
           - path: /api
             pathType: Prefix
@@ -67,3 +77,32 @@ spec:
                 name: spur-cloud-frontend
                 port:
                   number: 80
+---
+# NetworkPolicy: only the ingress-nginx controller may reach the frontend pod.
+# The ingress controller uses hostNetwork, so traffic appears from the node IP.
+# We allow both the ingress-nginx pod namespace and the API pod (for health checks).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: spur-cloud-frontend
+  namespace: spur-cloud
+spec:
+  podSelector:
+    matchLabels:
+      app: spur-cloud-frontend
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow from the ingress-nginx controller pod
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+    # Allow from the API pod (e.g. health checks / SSR)
+    - from:
+        - podSelector:
+            matchLabels:
+              app: spur-cloud-api


### PR DESCRIPTION
- Cargo.toml: upgrade kube 0.96 -> 0.97 to fix 500 error from K8s 1.35.4 removing SPDY; kube 0.97 uses v5.channel.k8s.io WebSocket exec
- ws.rs: look up pod by spur.ai/job-id label instead of stored pod_name since agent appends node suffix that DB doesn't capture
- ws_handler.rs: stderr: false when tty=true (cannot have both)
- configmap.yaml: add backend = "k8s" to [server] section
- gpuaas-api.yaml: amdaccelcloud image tag, add watch/update RBAC verbs, add NetworkPolicy restricting ingress to nginx controller and frontend
- gpuaas-frontend.yaml: amdaccelcloud image tag, ClusterIP service type, TLS ingress with ingressClassName, NetworkPolicy

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
