### PR TITLE
Fix session UX: Remove misleading CLI examples and fix rocm-smi availability

### DIFF
--- a/crates/spur-cloud-api/src/spur_client.rs
+++ b/crates/spur-cloud-api/src/spur_client.rs
@@ -201,8 +201,26 @@ pub async fn submit_session(
         "  export CUDA_VISIBLE_DEVICES=\"$SPUR_JOB_GPUS\"\n",
         "  export GPU_DEVICE_ORDINAL=\"$SPUR_JOB_GPUS\"\n",
         "  readonly ROCR_VISIBLE_DEVICES HIP_VISIBLE_DEVICES CUDA_VISIBLE_DEVICES GPU_DEVICE_ORDINAL\n",
-        "  alias rocm-smi='rocm-smi -d $SPUR_JOB_GPUS'\n",
         "  echo \"GPU session: device(s) $SPUR_JOB_GPUS allocated\"\n",
+        "fi\n",
+    );
+
+    // Issue #38: Create rocm-smi wrapper script instead of alias (works in all shells)
+    let rocm_smi_wrapper = concat!(
+        "# Create rocm-smi wrapper that auto-filters to allocated GPUs\n",
+        "if [ -n \"$SPUR_JOB_GPUS\" ] && command -v rocm-smi >/dev/null 2>&1; then\n",
+        "  ROCM_SMI_REAL=$(command -v rocm-smi)\n",
+        "  cat > /usr/local/bin/rocm-smi << 'WRAPPER'\n",
+        "#!/bin/bash\n",
+        "# Auto-generated wrapper to filter rocm-smi to allocated GPUs\n",
+        "ROCM_SMI_REAL=\"/opt/rocm/bin/rocm-smi\"\n",
+        "if [ -n \"$SPUR_JOB_GPUS\" ]; then\n",
+        "  exec \"$ROCM_SMI_REAL\" -d \"$SPUR_JOB_GPUS\" \"$@\"\n",
+        "else\n",
+        "  exec \"$ROCM_SMI_REAL\" \"$@\"\n",
+        "fi\n",
+        "WRAPPER\n",
+        "  chmod +x /usr/local/bin/rocm-smi\n",
         "fi\n",
     );
 
@@ -215,6 +233,7 @@ pub async fn submit_session(
             cat > /etc/profile.d/spur-gpu.sh << 'PROFILE'\n\
             {gpu_profile}\
             PROFILE\n\
+            {rocm_smi_wrapper}\
             mkdir -p /root/.ssh && chmod 700 /root/.ssh\n\
             if [ -n \"$GPUAAS_SSH_KEYS\" ]; then\n\
               echo \"$GPUAAS_SSH_KEYS\" > /root/.ssh/authorized_keys\n\
@@ -234,6 +253,7 @@ pub async fn submit_session(
             cat > /etc/profile.d/spur-gpu.sh << 'PROFILE'\n\
             {gpu_profile}\
             PROFILE\n\
+            {rocm_smi_wrapper}\
             exec sleep infinity\n",
         )
     };

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -144,30 +144,23 @@ export default function SessionDetail() {
               onCopy={copyToClipboard}
             />
             <CodeBlock
-              title="Submit a batch job via Spur CLI"
-              code={`srun --gres=gpu:${session.gpu_type}:${session.gpu_count} --partition=gpu python3 train.py`}
+              title="Check allocated GPUs"
+              code={`echo "Allocated GPUs: $SPUR_JOB_GPUS"
+echo "Visible devices: $ROCR_VISIBLE_DEVICES"`}
               onCopy={copyToClipboard}
             />
             <CodeBlock
-              title="Interactive shell with GPU"
-              code={`srun --gres=gpu:${session.gpu_type}:1 --partition=gpu --pty bash`}
+              title="Install packages as needed"
+              code={`pip install <package-name>`}
               onCopy={copyToClipboard}
             />
             <CodeBlock
-              title="Submit a batch script"
-              code={`cat << 'EOF' > job.sh
-#!/bin/bash
-#SBATCH --job-name=my-training
-#SBATCH --partition=gpu
-#SBATCH --gres=gpu:${session.gpu_type}:${session.gpu_count}
-#SBATCH --time=04:00:00
-
-echo "Running on $(hostname) with $SPUR_JOB_GPUS GPUs"
-rocm-smi
-python3 train.py --epochs 100
-EOF
-
-sbatch job.sh`}
+              title="Run your workload"
+              code={`# You have a bash shell with GPU access
+# Run any commands, scripts, or applications
+python3 your_script.py
+./your_binary
+# etc.`}
               onCopy={copyToClipboard}
             />
           </div>


### PR DESCRIPTION
## Summary
Fixes #37 and #38 - Two UX issues affecting session usability.

## Issue #37: Remove misleading srun/sbatch examples
**Problem**: The frontend displayed examples using `srun` and `sbatch` commands, but these Slurm CLI tools are not installed in session containers. Users were misled by the UI showing commands that don't work.

**Solution**: Replaced with accurate, generic examples showing:
- Checking allocated GPUs via environment variables (`$SPUR_JOB_GPUS`, `$ROCR_VISIBLE_DEVICES`)
- Installing packages as needed (`pip install`)
- Running user workloads (user decides what to run in the bash shell)

## Issue #38: Fix rocm-smi inconsistent availability  
**Problem**: The `rocm-smi` command was configured as a bash alias in `/etc/profile.d/spur-gpu.sh`, which only works in login shells. This caused intermittent failures in:
- Web terminal (uses `bash` not `bash -l`)
- Direct SSH command execution (`ssh host 'rocm-smi'`)
- Non-interactive shells

**Solution**: Replaced bash alias with an executable wrapper script at `/usr/local/bin/rocm-smi` that:
- Intercepts all rocm-smi calls
- Automatically adds `-d $SPUR_JOB_GPUS` flag to filter to allocated GPUs
- Works in all shell contexts (login, non-login, interactive, non-interactive)

## Changes
- `frontend/src/pages/SessionDetail.tsx`: Removed srun/sbatch examples, added generic session usage examples
- `crates/spur-cloud-api/src/spur_client.rs`: Created rocm-smi wrapper script instead of alias

## Testing
- ✅ Rust backend: `cargo check` passes with no errors
- ✅ Frontend: `npm run build` completes successfully  
- ✅ Wrapper script: bash syntax validated
- ✅ Both K8s and bare-metal deployment modes supported

## Verification Steps
1. Launch a session with SSH enabled
2. Open web terminal → run `rocm-smi` → should work
3. SSH to session → run `rocm-smi` directly → should work
4. Run `ssh session 'rocm-smi'` (non-login shell) → should work
5. Verify UI shows correct examples (no srun/sbatch references)

## Backward Compatibility
- No breaking changes
- Frontend-only changes for Issue #37
- Existing sessions continue to use alias (login shells only)
- New sessions get wrapper script (works everywhere)