### PR TITLE
Make GPU optional — allow CPU-only sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,30 @@ jobs:
           PROVIDERS=$(curl -sf http://localhost:9090/api/auth/providers)
           echo "$PROVIDERS" | grep -q "local" && echo "PASS: providers" || echo "WARN: providers response unexpected"
 
+          # Issue #48: Test CPU-only session creation (gpu_count=0)
+          CPU_SESSION=$(curl -s -w '\n%{http_code}' -X POST http://localhost:9090/api/sessions \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: Bearer $TOKEN" \
+            -d '{"name":"cpu-test","container_image":"ubuntu:22.04","gpu_count":0,"gpu_type":"none"}')
+          CPU_CODE=$(echo "$CPU_SESSION" | tail -1)
+          if [ "$CPU_CODE" = "201" ]; then
+            echo "PASS: CPU-only session creation (gpu_count=0)"
+          else
+            echo "WARN: CPU-only session returned $CPU_CODE (spurctld may be down)"
+          fi
+
+          # Issue #48: Test cross-validation rejects gpu_count=0 with gpu_type set
+          INVALID=$(curl -s -w '\n%{http_code}' -X POST http://localhost:9090/api/sessions \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: Bearer $TOKEN" \
+            -d '{"name":"bad","container_image":"ubuntu:22.04","gpu_count":0,"gpu_type":"mi300x"}')
+          INVALID_CODE=$(echo "$INVALID" | tail -1)
+          if [ "$INVALID_CODE" = "400" ]; then
+            echo "PASS: cross-validation rejects gpu_count=0 + gpu_type=mi300x"
+          else
+            echo "FAIL: expected 400, got $INVALID_CODE"; kill $API_PID 2>/dev/null; exit 1
+          fi
+
           # GPU capacity (requires spurctld)
           GPU=$(curl -sf http://localhost:9090/api/gpus -H "Authorization: Bearer $TOKEN" 2>/dev/null)
           echo "GPU capacity: $GPU"

--- a/crates/spur-cloud-api/src/db/migrations.rs
+++ b/crates/spur-cloud-api/src/db/migrations.rs
@@ -96,6 +96,11 @@ pub async fn run_migrations(pool: &PgPool) -> anyhow::Result<()> {
         .execute(pool)
         .await?;
 
+    // Issue #48: Default gpu_count to 0 (CPU-only) for new sessions
+    sqlx::query("ALTER TABLE sessions ALTER COLUMN gpu_count SET DEFAULT 0")
+        .execute(pool)
+        .await?;
+
     info!("database migrations complete");
     Ok(())
 }

--- a/crates/spur-cloud-api/src/routes/sessions.rs
+++ b/crates/spur-cloud-api/src/routes/sessions.rs
@@ -28,39 +28,57 @@ fn default_limit() -> i64 {
     50
 }
 
-/// POST /api/sessions — launch a new GPU session
+/// POST /api/sessions — launch a new session (GPU or CPU-only)
 pub async fn create_session(
     State(state): State<AppState>,
     Extension(principal): Extension<Principal>,
     Json(req): Json<CreateSessionRequest>,
 ) -> impl IntoResponse {
-    // Validate
-    if req.gpu_count < 1 || req.gpu_count > 8 {
-        return (StatusCode::BAD_REQUEST, "gpu_count must be 1-8").into_response();
+    // Validate gpu_count range (0 = CPU-only, 1-8 = GPU session)
+    if req.gpu_count < 0 || req.gpu_count > 8 {
+        return (StatusCode::BAD_REQUEST, "gpu_count must be 0-8").into_response();
     }
 
-    // Issue #36: Check per-user GPU quota
-    if let Ok(Some(user)) = user_repo::get_user_by_id(&state.db, principal.user_id).await {
-        if let Some(max_gpus) = user.max_gpus {
-            let active_gpus =
-                session_repo::count_active_gpus_for_user(&state.db, principal.user_id)
-                    .await
-                    .unwrap_or(0);
-            let requested = req.gpu_count as i64;
-            if active_gpus + requested > max_gpus as i64 {
-                return (
-                    StatusCode::FORBIDDEN,
-                    format!(
-                        "GPU quota exceeded: you are using {active_gpus}/{max_gpus} GPUs, requested {requested} more"
-                    ),
-                )
-                    .into_response();
+    // Issue #48: Cross-validate gpu_type and gpu_count
+    if req.gpu_count == 0 && req.gpu_type != "none" {
+        return (
+            StatusCode::BAD_REQUEST,
+            "gpu_type must be 'none' when gpu_count is 0 (CPU-only session)",
+        )
+            .into_response();
+    }
+    if req.gpu_count > 0 && req.gpu_type == "none" {
+        return (
+            StatusCode::BAD_REQUEST,
+            "gpu_type must be specified when gpu_count > 0",
+        )
+            .into_response();
+    }
+
+    // Issue #36: Check per-user GPU quota (skip for CPU-only sessions)
+    if req.gpu_count > 0 {
+        if let Ok(Some(user)) = user_repo::get_user_by_id(&state.db, principal.user_id).await {
+            if let Some(max_gpus) = user.max_gpus {
+                let active_gpus =
+                    session_repo::count_active_gpus_for_user(&state.db, principal.user_id)
+                        .await
+                        .unwrap_or(0);
+                let requested = req.gpu_count as i64;
+                if active_gpus + requested > max_gpus as i64 {
+                    return (
+                        StatusCode::FORBIDDEN,
+                        format!(
+                            "GPU quota exceeded: you are using {active_gpus}/{max_gpus} GPUs, requested {requested} more"
+                        ),
+                    )
+                        .into_response();
+                }
             }
         }
     }
 
-    // Issue #14: Check GPU capacity before creating session
-    {
+    // Issue #14: Check GPU capacity before creating session (skip for CPU-only)
+    if req.gpu_count > 0 {
         let mut spur = state.spur.clone();
         match spur_client::get_gpu_capacity(&mut spur).await {
             Ok(pools) => {

--- a/crates/spur-cloud-api/src/spur_client.rs
+++ b/crates/spur-cloud-api/src/spur_client.rs
@@ -112,13 +112,17 @@ pub async fn create_spurjob_crd(
         SpurJobSpec {
             name: name.to_string(),
             image: container_image.to_string(),
-            gpus: GpuSpec {
-                count: gpu_count as u32,
-                gpu_type: Some(gpu_type.to_string()),
+            gpus: if gpu_count > 0 {
+                GpuSpec {
+                    count: gpu_count as u32,
+                    gpu_type: Some(gpu_type.to_string()),
+                }
+            } else {
+                GpuSpec::default()
             },
             num_nodes: 1,
             tasks_per_node: 1,
-            cpus_per_task: 8,
+            cpus_per_task: if gpu_count > 0 { 8 } else { 4 },
             time_limit: Some(format!("{}m", time_limit_min)),
             command: vec![],
             args: vec![],
@@ -229,16 +233,22 @@ pub async fn submit_session(
         "fi\n",
     );
 
-    let script = if ssh_enabled {
-        // Entrypoint starts sshd then sleeps.
-        // GPUAAS_SSH_PORT is set by the platform for bare-metal mode (deterministic port);
-        // defaults to 22 for K8s mode where NodePort handles port mapping.
+    // Issue #48: Only include GPU profile and rocm-smi wrapper for GPU sessions
+    let gpu_setup = if gpu_count > 0 {
         format!(
-            "#!/bin/bash\n\
-            cat > /etc/profile.d/spur-gpu.sh << 'PROFILE'\n\
+            "cat > /etc/profile.d/spur-gpu.sh << 'PROFILE'\n\
             {gpu_profile}\
             PROFILE\n\
-            {rocm_smi_wrapper}\
+            {rocm_smi_wrapper}",
+        )
+    } else {
+        "# CPU-only session — no GPU profile\n".to_string()
+    };
+
+    let script = if ssh_enabled {
+        format!(
+            "#!/bin/bash\n\
+            {gpu_setup}\
             mkdir -p /root/.ssh && chmod 700 /root/.ssh\n\
             if [ -n \"$GPUAAS_SSH_KEYS\" ]; then\n\
               echo \"$GPUAAS_SSH_KEYS\" > /root/.ssh/authorized_keys\n\
@@ -255,12 +265,16 @@ pub async fn submit_session(
     } else {
         format!(
             "#!/bin/bash\n\
-            cat > /etc/profile.d/spur-gpu.sh << 'PROFILE'\n\
-            {gpu_profile}\
-            PROFILE\n\
-            {rocm_smi_wrapper}\
+            {gpu_setup}\
             exec sleep infinity\n",
         )
+    };
+
+    // Issue #48: CPU-only sessions use empty gres and fewer CPUs
+    let gres = if gpu_count > 0 {
+        vec![format!("gpu:{}:{}", gpu_type, gpu_count)]
+    } else {
+        vec![]
     };
 
     let spec = JobSpec {
@@ -268,8 +282,8 @@ pub async fn submit_session(
         partition: partition.unwrap_or_default().to_string(),
         num_nodes: 1,
         num_tasks: 1,
-        cpus_per_task: 8, // proportional: 8 CPUs per GPU
-        gres: vec![format!("gpu:{}:{}", gpu_type, gpu_count)],
+        cpus_per_task: if gpu_count > 0 { 8 } else { 4 },
+        gres,
         script,
         environment,
         time_limit: Some(prost_types::Duration {

--- a/crates/spur-cloud-common/src/session_types.rs
+++ b/crates/spur-cloud-common/src/session_types.rs
@@ -64,8 +64,11 @@ pub struct SessionSummary {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateSessionRequest {
     pub name: String,
+    /// GPU type. Defaults to "none" for CPU-only sessions.
+    #[serde(default = "default_gpu_type")]
     pub gpu_type: String,
-    #[serde(default = "default_gpu_count")]
+    /// Number of GPUs. 0 = CPU-only session.
+    #[serde(default)]
     pub gpu_count: i32,
     pub container_image: String,
     #[serde(default)]
@@ -75,8 +78,12 @@ pub struct CreateSessionRequest {
     pub partition: Option<String>,
 }
 
+fn default_gpu_type() -> String {
+    "none".into()
+}
+
 fn default_gpu_count() -> i32 {
-    1
+    0
 }
 
 fn default_time_limit() -> i32 {

--- a/frontend/src/components/SessionTable.tsx
+++ b/frontend/src/components/SessionTable.tsx
@@ -60,7 +60,7 @@ export default function SessionTable({ sessions }: Props) {
               </td>
               <td className="py-3">
                 <span className="font-mono text-sm">
-                  {s.gpu_count}x {s.gpu_type}
+                  {s.gpu_count === 0 ? 'CPU' : `${s.gpu_count}x ${s.gpu_type}`}
                 </span>
               </td>
               <td className="py-3">

--- a/frontend/src/pages/Billing.tsx
+++ b/frontend/src/pages/Billing.tsx
@@ -53,7 +53,7 @@ export default function Billing() {
               {summary.total_gpu_hours.toFixed(1)}
             </p>
           </div>
-          {summary.by_gpu_type.map(g => (
+          {summary.by_gpu_type.filter(g => g.gpu_type !== 'none').map(g => (
             <div key={g.gpu_type} className="bg-gray-900 border border-gray-800 rounded-lg p-6">
               <p className="text-sm text-gray-400 uppercase">{g.gpu_type}</p>
               <p className="text-3xl font-bold text-white mt-1">{g.gpu_hours.toFixed(1)}h</p>
@@ -84,7 +84,7 @@ export default function Billing() {
             ) : (
               records.map(r => (
                 <tr key={r.id} className="border-b border-gray-800/50">
-                  <td className="py-3 pl-4 font-mono text-sm uppercase">{r.gpu_type}</td>
+                  <td className="py-3 pl-4 font-mono text-sm uppercase">{r.gpu_type === 'none' ? 'CPU' : r.gpu_type}</td>
                   <td className="py-3 text-sm">{r.gpu_count}</td>
                   <td className="py-3 text-sm text-gray-400">
                     {new Date(r.start_time).toLocaleString()}

--- a/frontend/src/pages/NewSession.tsx
+++ b/frontend/src/pages/NewSession.tsx
@@ -14,8 +14,8 @@ export default function NewSession() {
   const navigate = useNavigate();
   const [gpuPools, setGpuPools] = useState<GpuPool[]>([]);
   const [name, setName] = useState('');
-  const [gpuType, setGpuType] = useState('');
-  const [gpuCount, setGpuCount] = useState(1);
+  const [gpuType, setGpuType] = useState('none');
+  const [gpuCount, setGpuCount] = useState(0);
   const [imagePreset, setImagePreset] = useState(defaultImages[0].value);
   const [customImage, setCustomImage] = useState('');
   const [sshEnabled, setSshEnabled] = useState(true);
@@ -26,7 +26,11 @@ export default function NewSession() {
   useEffect(() => {
     gpus.capacity().then(pools => {
       setGpuPools(pools);
-      if (pools.length > 0) setGpuType(pools[0].gpu_type);
+      // Auto-select first GPU pool if available; otherwise stay CPU-only
+      if (pools.length > 0) {
+        setGpuType(pools[0].gpu_type);
+        setGpuCount(1);
+      }
     }).catch(() => {});
   }, []);
 
@@ -34,7 +38,7 @@ export default function NewSession() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name || !containerImage || !gpuType) {
+    if (!name || !containerImage) {
       setError('Please fill in all required fields');
       return;
     }
@@ -62,7 +66,7 @@ export default function NewSession() {
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold text-white mb-6">Launch GPU Session</h1>
+      <h1 className="text-2xl font-bold text-white mb-6">Launch Session</h1>
 
       <form onSubmit={handleSubmit} className="bg-gray-900 border border-gray-800 rounded-xl p-8 space-y-6">
         {/* Session Name */}
@@ -78,15 +82,29 @@ export default function NewSession() {
           />
         </div>
 
-        {/* GPU Type */}
+        {/* Resource Type */}
         <div>
-          <label className="block text-sm font-medium text-gray-300 mb-1">GPU Type</label>
+          <label className="block text-sm font-medium text-gray-300 mb-1">Resources</label>
           <div className="grid grid-cols-2 gap-3">
+            {/* CPU-only option */}
+            <button
+              type="button"
+              onClick={() => { setGpuType('none'); setGpuCount(0); }}
+              className={`p-4 rounded-lg border text-left transition ${
+                gpuType === 'none'
+                  ? 'border-blue-500 bg-blue-900/20'
+                  : 'border-gray-700 bg-gray-800 hover:border-gray-600'
+              }`}
+            >
+              <div className="font-semibold text-white">CPU Only</div>
+              <div className="text-sm text-gray-400">No GPU — compute only</div>
+            </button>
+            {/* GPU pool options */}
             {gpuPools.map(pool => (
               <button
                 key={pool.gpu_type}
                 type="button"
-                onClick={() => setGpuType(pool.gpu_type)}
+                onClick={() => { setGpuType(pool.gpu_type); if (gpuCount === 0) setGpuCount(1); }}
                 className={`p-4 rounded-lg border text-left transition ${
                   gpuType === pool.gpu_type
                     ? 'border-blue-500 bg-blue-900/20'
@@ -95,34 +113,33 @@ export default function NewSession() {
               >
                 <div className="font-semibold text-white uppercase">{pool.gpu_type}</div>
                 <div className="text-sm text-gray-400">
-                  {pool.available}/{pool.total} available - {Math.round(pool.memory_mb / 1024)} GB
+                  {pool.available}/{pool.total} available — {Math.round(pool.memory_mb / 1024)} GB
                 </div>
               </button>
             ))}
-            {gpuPools.length === 0 && (
-              <p className="text-gray-500 col-span-2">No GPU types available</p>
-            )}
           </div>
         </div>
 
-        {/* GPU Count */}
-        <div>
-          <label className="block text-sm font-medium text-gray-300 mb-1">
-            GPUs: {gpuCount}
-          </label>
-          <input
-            type="range"
-            min={1}
-            max={maxGpus}
-            value={gpuCount}
-            onChange={e => setGpuCount(parseInt(e.target.value))}
-            className="w-full"
-          />
-          <div className="flex justify-between text-xs text-gray-500">
-            <span>1</span>
-            <span>{maxGpus}</span>
+        {/* GPU Count — only shown for GPU sessions */}
+        {gpuType !== 'none' && (
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">
+              GPUs: {gpuCount}
+            </label>
+            <input
+              type="range"
+              min={1}
+              max={maxGpus}
+              value={gpuCount}
+              onChange={e => setGpuCount(parseInt(e.target.value))}
+              className="w-full"
+            />
+            <div className="flex justify-between text-xs text-gray-500">
+              <span>1</span>
+              <span>{maxGpus}</span>
+            </div>
           </div>
-        </div>
+        )}
 
         {/* Container Image */}
         <div>

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -75,7 +75,7 @@ export default function SessionDetail() {
       <div className="bg-gray-900 border border-gray-800 rounded-lg p-6 mb-6">
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <InfoItem label="State" value={session.state} highlight={isRunning ? 'green' : isTerminal ? 'red' : 'yellow'} />
-          <InfoItem label="GPU" value={`${session.gpu_count}x ${session.gpu_type}`} />
+          <InfoItem label="Resources" value={session.gpu_count === 0 ? 'CPU only' : `${session.gpu_count}x ${session.gpu_type}`} />
           <InfoItem label="Node" value={session.node_name || 'pending'} />
           <InfoItem label="Time Limit" value={`${session.time_limit_min} min`} />
           <InfoItem label="Created" value={new Date(session.created_at).toLocaleString()} />
@@ -123,13 +123,13 @@ export default function SessionDetail() {
         </div>
       )}
 
-      {/* Job Examples */}
-      {isRunning && session.node_name && (
+      {/* Job Examples — GPU sessions */}
+      {isRunning && session.node_name && session.gpu_count > 0 && (
         <div className="bg-gray-900 border border-gray-800 rounded-lg p-6 mb-6">
-          <h2 className="text-lg font-semibold text-white mb-3">Running Jobs on Your Session</h2>
+          <h2 className="text-lg font-semibold text-white mb-3">Running Jobs on Your GPU Session</h2>
           <p className="text-gray-400 text-sm mb-4">
             Your session has {session.gpu_count}x {session.gpu_type} GPU(s) allocated.
-            Use the web terminal above or SSH to run commands. Here are some examples:
+            Use the web terminal above or SSH to run commands.
           </p>
 
           <div className="space-y-4">
@@ -149,18 +149,27 @@ export default function SessionDetail() {
 echo "Visible devices: $ROCR_VISIBLE_DEVICES"`}
               onCopy={copyToClipboard}
             />
+          </div>
+        </div>
+      )}
+
+      {/* Job Examples — CPU-only sessions */}
+      {isRunning && session.node_name && session.gpu_count === 0 && (
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-6 mb-6">
+          <h2 className="text-lg font-semibold text-white mb-3">Running Jobs on Your CPU Session</h2>
+          <p className="text-gray-400 text-sm mb-4">
+            Your session has CPU-only resources. Use the web terminal above or SSH to run commands.
+          </p>
+
+          <div className="space-y-4">
             <CodeBlock
-              title="Install packages as needed"
-              code={`pip install <package-name>`}
+              title="Check system resources"
+              code={`nproc && free -h`}
               onCopy={copyToClipboard}
             />
             <CodeBlock
               title="Run your workload"
-              code={`# You have a bash shell with GPU access
-# Run any commands, scripts, or applications
-python3 your_script.py
-./your_binary
-# etc.`}
+              code={`python3 your_script.py`}
               onCopy={copyToClipboard}
             />
           </div>


### PR DESCRIPTION
## Summary

Makes GPU support runtime-optional instead of required. Sessions now default to CPU-only (`gpu_count=0, gpu_type="none"`) and GPU resources are only requested when explicitly specified.

This is a runtime approach rather than a compile-time feature flag — a single binary serves both GPU and CPU-only clusters.

### Backend
- `CreateSessionRequest` defaults: `gpu_count=0`, `gpu_type="none"`
- Validation allows `gpu_count=0` (was: must be 1-8)
- Cross-validates: `gpu_count=0` requires `gpu_type="none"` and vice versa
- Skips GPU capacity/quota checks for CPU-only sessions
- `submit_session()`: empty `gres`, skip GPU profile, 4 CPUs for CPU-only
- DB migration: default `gpu_count` to 0

### Frontend
- "CPU Only" button in session creation form
- GPU count slider hidden when CPU-only selected
- Session table/detail: shows "CPU" instead of "0x none"
- CPU-specific examples in session detail
- Billing: filters "none" from GPU summary

## Test plan

- [x] 16 backend tests pass
- [x] Frontend builds clean
- [x] `cargo fmt --check` clean
- [ ] CI integration tests: CPU-only session creation + cross-validation
- [ ] Manual: create CPU-only session, verify it runs on spur node

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)