### PR TITLE
chore(ci): clippy cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
             ${{ runner.os }}-cargo-clippy-
 
       - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -W clippy::all
+        run: cargo clippy --workspace --all-targets --locked -- -W clippy::all
+
 
   frontend:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -86,7 +86,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -666,7 +666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1708,7 +1708,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2348,7 +2348,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2733,7 +2733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2807,8 +2807,8 @@ dependencies = [
 
 [[package]]
 name = "spur-proto"
-version = "0.1.0"
-source = "git+https://github.com/ROCm/spur.git?branch=main#123a5ab9df749f50dfec8a2b3c50bd8beb42a6c3"
+version = "0.3.0"
+source = "git+https://github.com/ROCm/spur.git?tag=v0.3.0#41de8e2fe09b9930bd570dc981b3eec3de23e768"
 dependencies = [
  "prost",
  "prost-types",
@@ -3081,10 +3081,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,8 @@ rand = "0.8"
 sha2 = "0.10"
 semver = "1"
 
-# Spur proto (git dependency from ROCm/spur main branch)
-spur-proto = { git = "https://github.com/ROCm/spur.git", branch = "main" }
+# Spur proto — pinned to ROCm/spur release tag (see Cargo.lock for exact commit)
+spur-proto = { git = "https://github.com/ROCm/spur.git", tag = "v0.3.0" }
 
 # Internal
 spur-cloud-common = { path = "crates/spur-cloud-common" }

--- a/crates/spur-cloud-api/src/auth/oidc_common.rs
+++ b/crates/spur-cloud-api/src/auth/oidc_common.rs
@@ -7,7 +7,6 @@ use tracing::debug;
 pub struct OidcDiscovery {
     pub authorization_endpoint: String,
     pub token_endpoint: String,
-    pub jwks_uri: String,
     pub issuer: String,
 }
 
@@ -23,12 +22,10 @@ pub async fn fetch_discovery(issuer: &str) -> anyhow::Result<OidcDiscovery> {
     Ok(discovery)
 }
 
-/// OIDC token response.
+/// OIDC token response (only fields we use).
 #[derive(Debug, Deserialize)]
 pub struct TokenResponse {
-    pub access_token: String,
     pub id_token: Option<String>,
-    pub token_type: String,
 }
 
 /// Exchange authorization code for tokens.
@@ -70,8 +67,21 @@ pub fn decode_id_token_unverified(id_token: &str) -> anyhow::Result<IdTokenClaim
     Ok(claims)
 }
 
+/// Reject ID tokens whose `iss` does not match the configured Okta issuer.
+pub fn validate_id_token_issuer(
+    claims: &IdTokenClaims,
+    expected_issuer: &str,
+) -> Result<(), &'static str> {
+    match &claims.iss {
+        Some(iss) if iss == expected_issuer => Ok(()),
+        Some(_) => Err("ID token issuer mismatch"),
+        None => Err("ID token missing iss claim"),
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct IdTokenClaims {
+    pub iss: Option<String>,
     pub sub: String,
     pub email: Option<String>,
     pub name: Option<String>,

--- a/crates/spur-cloud-api/src/auth/okta.rs
+++ b/crates/spur-cloud-api/src/auth/okta.rs
@@ -111,6 +111,11 @@ pub async fn okta_callback(
         }
     };
 
+    if let Err(e) = oidc_common::validate_id_token_issuer(&claims, &discovery.issuer) {
+        error!("Okta ID token issuer validation failed: {e}");
+        return (StatusCode::BAD_GATEWAY, "invalid ID token").into_response();
+    }
+
     let email = claims
         .email
         .unwrap_or_else(|| format!("{}@okta.local", claims.sub));

--- a/crates/spur-cloud-api/src/db/session_repo.rs
+++ b/crates/spur-cloud-api/src/db/session_repo.rs
@@ -2,19 +2,9 @@ use chrono::Utc;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use crate::models::session::Session;
+use crate::models::session::{NewSession, Session};
 
-pub async fn create_session(
-    pool: &PgPool,
-    user_id: Uuid,
-    name: &str,
-    gpu_type: &str,
-    gpu_count: i32,
-    container_image: &str,
-    partition: Option<&str>,
-    ssh_enabled: bool,
-    time_limit_min: i32,
-) -> sqlx::Result<Session> {
+pub async fn create_session(pool: &PgPool, session: NewSession<'_>) -> sqlx::Result<Session> {
     sqlx::query_as::<_, Session>(
         r#"
         INSERT INTO sessions (user_id, name, gpu_type, gpu_count, container_image, partition, ssh_enabled, time_limit_min)
@@ -22,23 +12,16 @@ pub async fn create_session(
         RETURNING *
         "#,
     )
-    .bind(user_id)
-    .bind(name)
-    .bind(gpu_type)
-    .bind(gpu_count)
-    .bind(container_image)
-    .bind(partition)
-    .bind(ssh_enabled)
-    .bind(time_limit_min)
+    .bind(session.user_id)
+    .bind(session.name)
+    .bind(session.gpu_type)
+    .bind(session.gpu_count)
+    .bind(session.container_image)
+    .bind(session.partition)
+    .bind(session.ssh_enabled)
+    .bind(session.time_limit_min)
     .fetch_one(pool)
     .await
-}
-
-pub async fn get_session(pool: &PgPool, id: Uuid) -> sqlx::Result<Option<Session>> {
-    sqlx::query_as::<_, Session>("SELECT * FROM sessions WHERE id = $1")
-        .bind(id)
-        .fetch_optional(pool)
-        .await
 }
 
 pub async fn get_session_for_user(

--- a/crates/spur-cloud-api/src/db/user_repo.rs
+++ b/crates/spur-cloud-api/src/db/user_repo.rs
@@ -38,13 +38,6 @@ pub async fn get_user_by_email(pool: &PgPool, email: &str) -> sqlx::Result<Optio
         .await
 }
 
-pub async fn get_user_by_username(pool: &PgPool, username: &str) -> sqlx::Result<Option<User>> {
-    sqlx::query_as::<_, User>("SELECT * FROM users WHERE username = $1")
-        .bind(username)
-        .fetch_optional(pool)
-        .await
-}
-
 pub async fn upsert_github_user(
     pool: &PgPool,
     github_id: i64,
@@ -106,20 +99,6 @@ pub async fn upsert_okta_user(
 pub async fn update_last_login(pool: &PgPool, id: Uuid) -> sqlx::Result<()> {
     sqlx::query("UPDATE users SET last_login_at = NOW() WHERE id = $1")
         .bind(id)
-        .execute(pool)
-        .await?;
-    Ok(())
-}
-
-/// Issue #36: Set per-user GPU quota. NULL = unlimited.
-pub async fn set_user_gpu_quota(
-    pool: &PgPool,
-    user_id: Uuid,
-    max_gpus: Option<i32>,
-) -> sqlx::Result<()> {
-    sqlx::query("UPDATE users SET max_gpus = $2 WHERE id = $1")
-        .bind(user_id)
-        .bind(max_gpus)
         .execute(pool)
         .await?;
     Ok(())

--- a/crates/spur-cloud-api/src/main.rs
+++ b/crates/spur-cloud-api/src/main.rs
@@ -151,8 +151,8 @@ async fn handle_k8s_crd_session(state: &AppState, session: &models::session::Ses
     }
 
     let node = status.assigned_nodes.first().cloned().unwrap_or_default();
-    let current_state = SessionState::from_str(&session.state);
-    let crd_state = SessionState::from_str(&status.state.to_lowercase());
+    let current_state = SessionState::parse(&session.state);
+    let crd_state = SessionState::parse(&status.state.to_lowercase());
 
     match crd_state {
         SessionState::Running if !node.is_empty() => {
@@ -360,7 +360,7 @@ async fn session_sync_loop(state: AppState) {
             let spur_state = job.state();
             let exit_code = job.exit_code;
 
-            let current_state = SessionState::from_str(&session.state);
+            let current_state = SessionState::parse(&session.state);
 
             // Match on Spur state first, then check backend type only for Running state
             let new_state = match spur_state {

--- a/crates/spur-cloud-api/src/models/session.rs
+++ b/crates/spur-cloud-api/src/models/session.rs
@@ -4,6 +4,18 @@ use uuid::Uuid;
 
 use spur_cloud_common::session_types::SessionState;
 
+/// Fields for inserting a new session row.
+pub struct NewSession<'a> {
+    pub user_id: Uuid,
+    pub name: &'a str,
+    pub gpu_type: &'a str,
+    pub gpu_count: i32,
+    pub container_image: &'a str,
+    pub partition: Option<&'a str>,
+    pub ssh_enabled: bool,
+    pub time_limit_min: i32,
+}
+
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct Session {
     pub id: Uuid,
@@ -35,6 +47,7 @@ pub struct SessionDetail {
     pub gpu_type: String,
     pub gpu_count: i32,
     pub container_image: String,
+    pub partition: Option<String>,
     pub ssh_enabled: bool,
     pub ssh_host: Option<String>,
     pub ssh_port: Option<i32>,
@@ -44,6 +57,7 @@ pub struct SessionDetail {
     pub started_at: Option<DateTime<Utc>>,
     pub ended_at: Option<DateTime<Utc>>,
     pub node_name: Option<String>,
+    pub pod_name: Option<String>,
     pub error_message: Option<String>,
 }
 
@@ -52,10 +66,11 @@ impl From<Session> for SessionDetail {
         Self {
             id: s.id,
             name: s.name,
-            state: SessionState::from_str(&s.state),
+            state: SessionState::parse(&s.state),
             gpu_type: s.gpu_type,
             gpu_count: s.gpu_count,
             container_image: s.container_image,
+            partition: s.partition,
             ssh_enabled: s.ssh_enabled,
             ssh_host: s.ssh_host,
             ssh_port: s.ssh_port,
@@ -65,6 +80,7 @@ impl From<Session> for SessionDetail {
             started_at: s.started_at,
             ended_at: s.ended_at,
             node_name: s.node_name,
+            pod_name: s.pod_name,
             error_message: s.error_message,
         }
     }

--- a/crates/spur-cloud-api/src/models/user.rs
+++ b/crates/spur-cloud-api/src/models/user.rs
@@ -28,11 +28,26 @@ pub struct UserProfile {
     pub display_name: Option<String>,
     pub avatar_url: Option<String>,
     pub is_admin: bool,
+    pub spur_account: String,
+    /// How this user authenticates: `github`, `okta`, or `local`.
+    pub auth_provider: String,
+    pub last_login_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
+}
+
+fn auth_provider_for(user: &User) -> String {
+    if user.github_id.is_some() {
+        "github".into()
+    } else if user.okta_sub.is_some() {
+        "okta".into()
+    } else {
+        "local".into()
+    }
 }
 
 impl From<User> for UserProfile {
     fn from(u: User) -> Self {
+        let auth_provider = auth_provider_for(&u);
         Self {
             id: u.id,
             email: u.email,
@@ -40,6 +55,9 @@ impl From<User> for UserProfile {
             display_name: u.display_name,
             avatar_url: u.avatar_url,
             is_admin: u.is_admin,
+            spur_account: u.spur_account,
+            auth_provider,
+            last_login_at: u.last_login_at,
             created_at: u.created_at,
         }
     }

--- a/crates/spur-cloud-api/src/routes/sessions.rs
+++ b/crates/spur-cloud-api/src/routes/sessions.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 use crate::auth::principal::Principal;
 use crate::config::Backend;
 use crate::db::{session_repo, ssh_key_repo, user_repo};
-use crate::models::session::SessionDetail;
+use crate::models::session::{NewSession, SessionDetail};
 use crate::spur_client;
 use crate::ssh;
 use crate::state::AppState;
@@ -107,14 +107,16 @@ pub async fn create_session(
     // Create session in DB
     let session = match session_repo::create_session(
         &state.db,
-        principal.user_id,
-        &req.name,
-        &req.gpu_type,
-        req.gpu_count,
-        &req.container_image,
-        req.partition.as_deref(),
-        req.ssh_enabled,
-        req.time_limit_min,
+        NewSession {
+            user_id: principal.user_id,
+            name: &req.name,
+            gpu_type: &req.gpu_type,
+            gpu_count: req.gpu_count,
+            container_image: &req.container_image,
+            partition: req.partition.as_deref(),
+            ssh_enabled: req.ssh_enabled,
+            time_limit_min: req.time_limit_min,
+        },
     )
     .await
     {
@@ -151,6 +153,8 @@ pub async fn create_session(
         None
     };
 
+    let session_id_str = session.id.to_string();
+
     // Submit to Spur — different paths for K8s and native-host
     match state.config.server.backend {
         Backend::K8s => {
@@ -161,17 +165,16 @@ pub async fn create_session(
                 .as_ref()
                 .expect("k8s backend requires kube client");
             let ns = &state.config.server.session_namespace;
-            match spur_client::create_spurjob_crd(
+            match spur_client::create_spurjob_crd(spur_client::CreateSpurJobCrdParams {
                 kube_client,
-                ns,
-                &session.id.to_string(),
-                &req.name,
-                &req.gpu_type,
-                req.gpu_count,
-                &req.container_image,
-                req.time_limit_min,
-                req.ssh_enabled,
-            )
+                namespace: ns,
+                session_id: &session_id_str,
+                name: &req.name,
+                gpu_type: &req.gpu_type,
+                gpu_count: req.gpu_count,
+                container_image: &req.container_image,
+                time_limit_min: req.time_limit_min,
+            })
             .await
             {
                 Ok(crd_name) => {
@@ -190,21 +193,34 @@ pub async fn create_session(
         }
         Backend::NativeHost => {
             // Native-host mode: submit directly to spurctld via gRPC
+            let user = match user_repo::get_user_by_id(&state.db, principal.user_id).await {
+                Ok(Some(u)) => u,
+                Ok(None) => {
+                    return (StatusCode::INTERNAL_SERVER_ERROR, "user not found").into_response();
+                }
+                Err(e) => {
+                    error!("user lookup failed: {e}");
+                    return (StatusCode::INTERNAL_SERVER_ERROR, "session creation failed")
+                        .into_response();
+                }
+            };
             let mut spur = state.spur.clone();
-            match spur_client::submit_session(
-                &mut spur,
-                &req.name,
-                &req.gpu_type,
-                req.gpu_count,
-                &req.container_image,
-                req.partition.as_deref(),
-                req.ssh_enabled,
-                req.time_limit_min,
-                &session.id.to_string(),
-                &ssh_keys_str,
+            match spur_client::submit_session(spur_client::SubmitSessionParams {
+                client: &mut spur,
+                name: &req.name,
+                gpu_type: &req.gpu_type,
+                gpu_count: req.gpu_count,
+                container_image: &req.container_image,
+                partition: req.partition.as_deref(),
+                ssh_enabled: req.ssh_enabled,
+                time_limit_min: req.time_limit_min,
+                session_id: &session_id_str,
+                ssh_keys: &ssh_keys_str,
                 ssh_port,
-                true, // native_host
-            )
+                native_host: true,
+                spur_user: &user.username,
+                spur_account: &user.spur_account,
+            })
             .await
             {
                 Ok(job_id) => {

--- a/crates/spur-cloud-api/src/routes/users.rs
+++ b/crates/spur-cloud-api/src/routes/users.rs
@@ -51,7 +51,7 @@ pub async fn add_ssh_key(
     Json(req): Json<AddSshKeyRequest>,
 ) -> impl IntoResponse {
     // Validate SSH key format
-    let parts: Vec<&str> = req.public_key.trim().split_whitespace().collect();
+    let parts: Vec<&str> = req.public_key.split_whitespace().collect();
     if parts.len() < 2 {
         return (StatusCode::BAD_REQUEST, "invalid SSH public key format").into_response();
     }
@@ -97,13 +97,13 @@ fn compute_fingerprint(public_key: &str) -> String {
     use base64::Engine;
     use sha2::{Digest, Sha256};
 
-    let parts: Vec<&str> = public_key.trim().split_whitespace().collect();
+    let parts: Vec<&str> = public_key.split_whitespace().collect();
     if parts.len() >= 2 {
         if let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(parts[1]) {
             let digest = Sha256::digest(&decoded);
             return format!(
                 "SHA256:{}",
-                base64::engine::general_purpose::STANDARD_NO_PAD.encode(&digest)
+                base64::engine::general_purpose::STANDARD_NO_PAD.encode(digest)
             );
         }
     }
@@ -111,6 +111,6 @@ fn compute_fingerprint(public_key: &str) -> String {
     let digest = Sha256::digest(public_key.as_bytes());
     format!(
         "SHA256:{}",
-        base64::engine::general_purpose::STANDARD_NO_PAD.encode(&digest)
+        base64::engine::general_purpose::STANDARD_NO_PAD.encode(digest)
     )
 }

--- a/crates/spur-cloud-api/src/spur_client.rs
+++ b/crates/spur-cloud-api/src/spur_client.rs
@@ -13,21 +13,12 @@ use spur_proto::proto::*;
 // ── SpurJob CRD (minimal definition matching spur-k8s operator) ──
 
 /// GPU configuration for a SpurJob.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct GpuSpec {
     pub count: u32,
     #[serde(default)]
     pub gpu_type: Option<String>,
-}
-
-impl Default for GpuSpec {
-    fn default() -> Self {
-        Self {
-            count: 0,
-            gpu_type: None,
-        }
-    }
 }
 
 /// SpurJob status — matches the operator's SpurJobStatus.
@@ -81,49 +72,57 @@ fn default_one() -> u32 {
     1
 }
 
+/// Parameters for creating a SpurJob CRD (K8s backend).
+pub struct CreateSpurJobCrdParams<'a> {
+    pub kube_client: &'a kube::Client,
+    pub namespace: &'a str,
+    pub session_id: &'a str,
+    pub name: &'a str,
+    pub gpu_type: &'a str,
+    pub gpu_count: i32,
+    pub container_image: &'a str,
+    pub time_limit_min: i32,
+}
+
 /// Create a SpurJob CRD in Kubernetes for a spur-cloud session.
 ///
 /// Used when `backend = "k8s"`. The spur-k8s operator watches for SpurJob
 /// resources, submits them to spurctld, and creates pods.
-pub async fn create_spurjob_crd(
-    kube_client: &kube::Client,
-    namespace: &str,
-    session_id: &str,
-    name: &str,
-    gpu_type: &str,
-    gpu_count: i32,
-    container_image: &str,
-    time_limit_min: i32,
-    ssh_enabled: bool,
-) -> anyhow::Result<String> {
-    let api: Api<SpurJob> = Api::namespaced(kube_client.clone(), namespace);
+pub async fn create_spurjob_crd(params: CreateSpurJobCrdParams<'_>) -> anyhow::Result<String> {
+    let api: Api<SpurJob> = Api::namespaced(params.kube_client.clone(), params.namespace);
 
-    let job_name = crd_name_for_session(session_id);
+    let job_name = crd_name_for_session(params.session_id);
 
     let mut labels = BTreeMap::new();
-    labels.insert("spur.ai/session-id".to_string(), session_id.to_string());
+    labels.insert(
+        "spur.ai/session-id".to_string(),
+        params.session_id.to_string(),
+    );
     labels.insert("spur.ai/managed-by".to_string(), "spur-cloud".to_string());
 
     let mut env = HashMap::new();
-    env.insert("GPUAAS_SESSION_ID".to_string(), session_id.to_string());
+    env.insert(
+        "GPUAAS_SESSION_ID".to_string(),
+        params.session_id.to_string(),
+    );
 
     let spurjob = SpurJob::new(
         &job_name,
         SpurJobSpec {
-            name: name.to_string(),
-            image: container_image.to_string(),
-            gpus: if gpu_count > 0 {
+            name: params.name.to_string(),
+            image: params.container_image.to_string(),
+            gpus: if params.gpu_count > 0 {
                 GpuSpec {
-                    count: gpu_count as u32,
-                    gpu_type: Some(gpu_type.to_string()),
+                    count: params.gpu_count as u32,
+                    gpu_type: Some(params.gpu_type.to_string()),
                 }
             } else {
                 GpuSpec::default()
             },
             num_nodes: 1,
             tasks_per_node: 1,
-            cpus_per_task: if gpu_count > 0 { 8 } else { 4 },
-            time_limit: Some(format!("{}m", time_limit_min)),
+            cpus_per_task: if params.gpu_count > 0 { 8 } else { 4 },
+            time_limit: Some(format!("{}m", params.time_limit_min)),
             command: vec![],
             args: vec![],
             env,
@@ -134,15 +133,15 @@ pub async fn create_spurjob_crd(
 
     let mut spurjob = spurjob;
     spurjob.metadata.labels = Some(labels);
-    spurjob.metadata.namespace = Some(namespace.to_string());
+    spurjob.metadata.namespace = Some(params.namespace.to_string());
 
     let created = api.create(&PostParams::default(), &spurjob).await?;
     let crd_name = created.metadata.name.unwrap_or_default();
 
     info!(
-        session_id,
+        session_id = params.session_id,
         crd_name = %crd_name,
-        namespace,
+        namespace = params.namespace,
         "SpurJob CRD created for K8s session"
     );
 
@@ -205,30 +204,35 @@ pub async fn delete_spurjob_crd(
     }
 }
 
+/// Parameters for submitting a session to spurctld (native-host backend).
+pub struct SubmitSessionParams<'a> {
+    pub client: &'a mut SlurmControllerClient<Channel>,
+    pub name: &'a str,
+    pub gpu_type: &'a str,
+    pub gpu_count: i32,
+    pub container_image: &'a str,
+    pub partition: Option<&'a str>,
+    pub ssh_enabled: bool,
+    pub time_limit_min: i32,
+    pub session_id: &'a str,
+    pub ssh_keys: &'a str,
+    pub ssh_port: Option<u16>,
+    pub native_host: bool,
+    pub spur_user: &'a str,
+    pub spur_account: &'a str,
+}
+
 /// Submit a GPU session as a Spur job. Returns the assigned job ID.
 ///
 /// `ssh_port`: If set, passed as GPUAAS_SSH_PORT (used in native-host mode for deterministic sshd port).
 /// `native_host`: If true, clears container_image so Spur runs the job as a bare process.
-pub async fn submit_session(
-    client: &mut SlurmControllerClient<Channel>,
-    name: &str,
-    gpu_type: &str,
-    gpu_count: i32,
-    container_image: &str,
-    partition: Option<&str>,
-    ssh_enabled: bool,
-    time_limit_min: i32,
-    session_id: &str,
-    ssh_keys: &str,
-    ssh_port: Option<u16>,
-    native_host: bool,
-) -> anyhow::Result<u32> {
+pub async fn submit_session(params: SubmitSessionParams<'_>) -> anyhow::Result<u32> {
     let mut environment = HashMap::new();
-    environment.insert("GPUAAS_SESSION_ID".into(), session_id.to_string());
-    if ssh_enabled && !ssh_keys.is_empty() {
-        environment.insert("GPUAAS_SSH_KEYS".into(), ssh_keys.to_string());
+    environment.insert("GPUAAS_SESSION_ID".into(), params.session_id.to_string());
+    if params.ssh_enabled && !params.ssh_keys.is_empty() {
+        environment.insert("GPUAAS_SSH_KEYS".into(), params.ssh_keys.to_string());
     }
-    if let Some(port) = ssh_port {
+    if let Some(port) = params.ssh_port {
         environment.insert("GPUAAS_SSH_PORT".into(), port.to_string());
     }
 
@@ -271,7 +275,7 @@ pub async fn submit_session(
     );
 
     // Issue #48: Only include GPU profile and rocm-smi wrapper for GPU sessions
-    let gpu_setup = if gpu_count > 0 {
+    let gpu_setup = if params.gpu_count > 0 {
         format!(
             "cat > /etc/profile.d/spur-gpu.sh << 'PROFILE'\n\
             {gpu_profile}\
@@ -282,7 +286,7 @@ pub async fn submit_session(
         "# CPU-only session — no GPU profile\n".to_string()
     };
 
-    let script = if ssh_enabled {
+    let script = if params.ssh_enabled {
         format!(
             "#!/bin/bash\n\
             {gpu_setup}\
@@ -308,41 +312,44 @@ pub async fn submit_session(
     };
 
     // Issue #48: CPU-only sessions use empty gres and fewer CPUs
-    let gres = if gpu_count > 0 {
-        vec![format!("gpu:{}:{}", gpu_type, gpu_count)]
+    let gres = if params.gpu_count > 0 {
+        vec![format!("gpu:{}:{}", params.gpu_type, params.gpu_count)]
     } else {
         vec![]
     };
 
     let spec = JobSpec {
-        name: name.to_string(),
-        partition: partition.unwrap_or_default().to_string(),
+        name: params.name.to_string(),
+        partition: params.partition.unwrap_or_default().to_string(),
+        user: params.spur_user.to_string(),
+        account: params.spur_account.to_string(),
         num_nodes: 1,
         num_tasks: 1,
-        cpus_per_task: if gpu_count > 0 { 8 } else { 4 },
+        cpus_per_task: if params.gpu_count > 0 { 8 } else { 4 },
         gres,
         script,
         environment,
         time_limit: Some(prost_types::Duration {
-            seconds: time_limit_min as i64 * 60,
+            seconds: params.time_limit_min as i64 * 60,
             nanos: 0,
         }),
         interactive: true,
         // Native-host mode: skip container image, run as bare process
-        container_image: if native_host {
+        container_image: if params.native_host {
             String::new()
         } else {
-            container_image.to_string()
+            params.container_image.to_string()
         },
         ..Default::default()
     };
 
-    let resp = client
+    let resp = params
+        .client
         .submit_job(SubmitJobRequest { spec: Some(spec) })
         .await?;
 
     let job_id = resp.into_inner().job_id;
-    debug!(job_id, name, "submitted session to spur");
+    debug!(job_id, name = params.name, "submitted session to spur");
     Ok(job_id)
 }
 

--- a/crates/spur-cloud-api/src/terminal/ws_handler.rs
+++ b/crates/spur-cloud-api/src/terminal/ws_handler.rs
@@ -140,7 +140,7 @@ pub async fn handle_terminal(
                 }
                 _ = ping_interval.tick() => {
                     // Issue #39: Send WebSocket ping to keep connection alive
-                    if ws_sink.send(Message::Ping(vec![].into())).await.is_err() {
+                    if ws_sink.send(Message::Ping(vec![])).await.is_err() {
                         debug!(pod = %pod_for_log2, "ws ping send failed — client disconnected");
                         break;
                     }
@@ -332,7 +332,7 @@ pub async fn handle_terminal_spur(
                 }
                 _ = ping_interval.tick() => {
                     // Issue #39: Send WebSocket ping to keep connection alive
-                    if ws_sink.send(Message::Ping(vec![].into())).await.is_err() {
+                    if ws_sink.send(Message::Ping(vec![])).await.is_err() {
                         debug!(job_id, "ws ping send failed — client disconnected");
                         break;
                     }
@@ -368,8 +368,10 @@ mod tests {
         assert!(WS_SEND_TIMEOUT < WS_PING_INTERVAL);
 
         // Verify retry count is reasonable
-        assert!(AGENT_CONNECT_RETRIES >= 1);
-        assert!(AGENT_CONNECT_RETRIES <= 10);
+        const {
+            assert!(AGENT_CONNECT_RETRIES >= 1);
+            assert!(AGENT_CONNECT_RETRIES <= 10);
+        }
     }
 
     #[test]

--- a/crates/spur-cloud-api/src/update.rs
+++ b/crates/spur-cloud-api/src/update.rs
@@ -139,6 +139,8 @@ pub fn spawn_startup_check(current_version: &'static str, config: &UpdateConfig)
         return;
     }
 
+    debug!(channel = %config.channel, "spawning startup update check");
+
     let cache_dir = PathBuf::from(&config.cache_dir);
 
     tokio::spawn(async move {

--- a/crates/spur-cloud-common/src/session_types.rs
+++ b/crates/spur-cloud-common/src/session_types.rs
@@ -29,7 +29,7 @@ impl SessionState {
         }
     }
 
-    pub fn from_str(s: &str) -> Self {
+    pub fn parse(s: &str) -> Self {
         match s {
             "creating" => Self::Creating,
             "pending" => Self::Pending,
@@ -83,10 +83,6 @@ pub struct CreateSessionRequest {
 
 fn default_gpu_type() -> String {
     "none".into()
-}
-
-fn default_gpu_count() -> i32 {
-    0
 }
 
 fn default_time_limit() -> i32 {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -67,6 +67,7 @@ export interface Session {
   gpu_type: string;
   gpu_count: number;
   container_image: string;
+  partition: string | null;
   ssh_enabled: boolean;
   ssh_host: string | null;
   ssh_port: number | null;
@@ -76,6 +77,7 @@ export interface Session {
   started_at: string | null;
   ended_at: string | null;
   node_name: string | null;
+  pod_name: string | null;
   error_message: string | null;
 }
 
@@ -141,6 +143,9 @@ export interface UserProfile {
   display_name: string | null;
   avatar_url: string | null;
   is_admin: boolean;
+  spur_account: string;
+  auth_provider: 'github' | 'okta' | 'local';
+  last_login_at: string | null;
   created_at: string;
 }
 


### PR DESCRIPTION
Resolve Clippy warnings without allow(dead_code) or allow(too_many_arguments): use parameter structs for session/Spur client calls, expose unused DB/API fields, trim OIDC types, and apply small lint fixes (trim/split_whitespace, needless borrows, WS ping).

Pin spur-proto to the ROCm/spur v0.3.0 git tag instead of tracking main so Cargo.lock is stable and `cargo clippy --locked` works.

Also align frontend Session/UserProfile types with the API.