### PR TITLE
refactor(k8s): rename spur.ai domain prefix to spur.amd.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ kubectl apply -f deploy/k8s/gpuaas-frontend.yaml
 Ensure GPU nodes are labeled for Spur:
 
 ```bash
-kubectl label node gpu-node-01 spur.ai/managed=true
-kubectl label node gpu-node-01 spur.ai/gpu-type=mi300x
+kubectl label node gpu-node-01 spur.amd.com/managed=true
+kubectl label node gpu-node-01 spur.amd.com/gpu-type=mi300x
 ```
 
 ## API

--- a/crates/spur-cloud-api/src/routes/ws.rs
+++ b/crates/spur-cloud-api/src/routes/ws.rs
@@ -49,7 +49,7 @@ pub async fn terminal_upgrade(
             // the status watcher does not capture when it writes pod_name to the DB.
             let pods: Api<Pod> = Api::namespaced(kube_client.clone(), &namespace);
             let lp = ListParams::default()
-                .labels(&format!("spur.ai/job-id={}", job_id))
+                .labels(&format!("spur.amd.com/job-id={}", job_id))
                 .limit(1);
             let pod_name = match pods.list(&lp).await {
                 Ok(list) => match list.items.into_iter().next().and_then(|p| p.metadata.name) {

--- a/crates/spur-cloud-api/src/spur_client.rs
+++ b/crates/spur-cloud-api/src/spur_client.rs
@@ -36,7 +36,7 @@ pub struct SpurJobStatus {
 /// SpurJob CRD spec — matches the operator's SpurJobSpec.
 #[derive(CustomResource, Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[kube(
-    group = "spur.ai",
+    group = "spur.amd.com",
     version = "v1alpha1",
     kind = "SpurJob",
     namespaced,
@@ -95,10 +95,13 @@ pub async fn create_spurjob_crd(params: CreateSpurJobCrdParams<'_>) -> anyhow::R
 
     let mut labels = BTreeMap::new();
     labels.insert(
-        "spur.ai/session-id".to_string(),
+        "spur.amd.com/session-id".to_string(),
         params.session_id.to_string(),
     );
-    labels.insert("spur.ai/managed-by".to_string(), "spur-cloud".to_string());
+    labels.insert(
+        "spur.amd.com/managed-by".to_string(),
+        "spur-cloud".to_string(),
+    );
 
     let mut env = HashMap::new();
     env.insert(

--- a/deploy/k8s/gpuaas-api.yaml
+++ b/deploy/k8s/gpuaas-api.yaml
@@ -85,7 +85,7 @@ rules:
     resources: ["services"]
     verbs: ["get", "list", "create", "delete"]
   # For SpurJob CRDs
-  - apiGroups: ["spur.ai"]
+  - apiGroups: ["spur.amd.com"]
     resources: ["spurjobs"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---


### PR DESCRIPTION
## Summary

- Replace all `spur.ai` references with `spur.amd.com` across CRD definitions, labels, RBAC rules, and documentation.
- Companion to the [spur repo PR](https://github.com/ROCm/spur/pulls) with the same rename — `spur.ai` is not a domain we own and K8s best practices require using a domain your organization controls for CRD API groups and label prefixes.

## What changed

| Area | Before | After |
|---|---|---|
| CRD API group (`spur_client.rs`) | `spur.ai` | `spur.amd.com` |
| Labels | `spur.ai/session-id`, `spur.ai/managed-by`, `spur.ai/job-id` | `spur.amd.com/session-id`, `spur.amd.com/managed-by`, `spur.amd.com/job-id` |
| RBAC apiGroups | `spur.ai` | `spur.amd.com` |
| README node labels | `spur.ai/managed`, `spur.ai/gpu-type` | `spur.amd.com/managed`, `spur.amd.com/gpu-type` |

4 files changed, pure find-and-replace. Build passes cleanly.

## Breaking change

This must be deployed together with the corresponding spur repo change — the CRD group changes from `spur.ai` to `spur.amd.com`.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt --check --all` — clean
- [x] Verified zero remaining `spur.ai` occurrences in the repo