### PR TITLE
ci: set RUSTFLAGS=-D warnings to fail on compiler warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Report warnings as errors.