### PR TITLE
chore(ci): add PR lint workflow and SPDX header pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Pre-commit checks:
+#   1. cargo fmt --check
+#   2. SPDX license headers on staged source files
+#
+# Bypass with: git commit --no-verify
+
+if command -v cargo >/dev/null 2>&1; then
+  if ! cargo fmt --all --check 2>/dev/null; then
+    echo "pre-commit: cargo fmt found unformatted code."
+    echo ""
+    echo "  Run: cargo fmt --all"
+    echo "  Bypass with: git commit --no-verify"
+    exit 1
+  fi
+fi
+
+# Check SPDX license headers on staged source files
+mapfile -t staged < <(
+    git diff --cached --name-only --diff-filter=d -- '*.rs' '*.proto' '*.py' '*.sh' '**/Dockerfile*'
+)
+
+if [ ${#staged[@]} -gt 0 ]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  "$REPO_ROOT/scripts/check-license-headers.sh" "${staged[@]}" || exit 1
+fi

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,37 @@
+name: PR Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    env:
+      PATTERN: "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\([a-zA-Z0-9_-]+\\))?!?: .+$"
+
+    steps:
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "Checking PR title: '$PR_TITLE'"
+          if ! echo "$PR_TITLE" | grep -Eq "$PATTERN"; then
+            echo "FAIL: PR title does not match conventional commits format."
+            echo "Expected: type(scope): description  (e.g. 'feat(spur-cloud-api): add session API')"
+            echo "Valid types: feat fix docs style refactor perf test build ci chore revert"
+            exit 1
+          fi
+          echo "PASS: PR title is valid."
+
+  license-headers:
+    name: SPDX License Headers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check SPDX license headers
+        run: ./scripts/check-license-headers.sh

--- a/crates/spur-cloud-api/src/auth/github.rs
+++ b/crates/spur-cloud-api/src/auth/github.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::{
     extract::{Query, State},
     http::StatusCode,

--- a/crates/spur-cloud-api/src/auth/jwt.rs
+++ b/crates/spur-cloud-api/src/auth/jwt.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{Duration, Utc};
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};

--- a/crates/spur-cloud-api/src/auth/middleware.rs
+++ b/crates/spur-cloud-api/src/auth/middleware.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::{
     extract::{Request, State},
     http::StatusCode,

--- a/crates/spur-cloud-api/src/auth/mod.rs
+++ b/crates/spur-cloud-api/src/auth/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod github;
 pub mod jwt;
 pub mod middleware;

--- a/crates/spur-cloud-api/src/auth/oidc_common.rs
+++ b/crates/spur-cloud-api/src/auth/oidc_common.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::http::HeaderMap;
 use serde::Deserialize;
 use tracing::debug;

--- a/crates/spur-cloud-api/src/auth/okta.rs
+++ b/crates/spur-cloud-api/src/auth/okta.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::{
     extract::{Query, State},
     http::StatusCode,

--- a/crates/spur-cloud-api/src/auth/principal.rs
+++ b/crates/spur-cloud-api/src/auth/principal.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use uuid::Uuid;
 
 /// Authenticated caller normalized at the application boundary.

--- a/crates/spur-cloud-api/src/config.rs
+++ b/crates/spur-cloud-api/src/config.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize, Default, PartialEq)]

--- a/crates/spur-cloud-api/src/db/billing_repo.rs
+++ b/crates/spur-cloud-api/src/db/billing_repo.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use sqlx::PgPool;

--- a/crates/spur-cloud-api/src/db/migrations.rs
+++ b/crates/spur-cloud-api/src/db/migrations.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use sqlx::PgPool;
 use tracing::info;
 

--- a/crates/spur-cloud-api/src/db/mod.rs
+++ b/crates/spur-cloud-api/src/db/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod billing_repo;
 pub mod migrations;
 pub mod session_repo;

--- a/crates/spur-cloud-api/src/db/session_repo.rs
+++ b/crates/spur-cloud-api/src/db/session_repo.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::Utc;
 use sqlx::PgPool;
 use uuid::Uuid;

--- a/crates/spur-cloud-api/src/db/ssh_key_repo.rs
+++ b/crates/spur-cloud-api/src/db/ssh_key_repo.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use sqlx::PgPool;
 use uuid::Uuid;
 

--- a/crates/spur-cloud-api/src/db/user_repo.rs
+++ b/crates/spur-cloud-api/src/db/user_repo.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use sqlx::PgPool;
 use uuid::Uuid;
 

--- a/crates/spur-cloud-api/src/main.rs
+++ b/crates/spur-cloud-api/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 mod auth;
 mod config;
 mod db;

--- a/crates/spur-cloud-api/src/models/mod.rs
+++ b/crates/spur-cloud-api/src/models/mod.rs
@@ -1,2 +1,5 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod session;
 pub mod user;

--- a/crates/spur-cloud-api/src/models/session.rs
+++ b/crates/spur-cloud-api/src/models/session.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use uuid::Uuid;

--- a/crates/spur-cloud-api/src/models/user.rs
+++ b/crates/spur-cloud-api/src/models/user.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;

--- a/crates/spur-cloud-api/src/routes/admin.rs
+++ b/crates/spur-cloud-api/src/routes/admin.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::extract::State;
 use axum::{http::StatusCode, response::IntoResponse, Extension, Json};
 use serde::Deserialize;

--- a/crates/spur-cloud-api/src/routes/auth.rs
+++ b/crates/spur-cloud-api/src/routes/auth.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 

--- a/crates/spur-cloud-api/src/routes/billing.rs
+++ b/crates/spur-cloud-api/src/routes/billing.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::{
     extract::{Query, State},
     http::StatusCode,

--- a/crates/spur-cloud-api/src/routes/gpus.rs
+++ b/crates/spur-cloud-api/src/routes/gpus.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use tracing::error;
 

--- a/crates/spur-cloud-api/src/routes/health.rs
+++ b/crates/spur-cloud-api/src/routes/health.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::{extract::State, http::StatusCode, response::IntoResponse};
 
 use crate::state::AppState;

--- a/crates/spur-cloud-api/src/routes/mod.rs
+++ b/crates/spur-cloud-api/src/routes/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod admin;
 pub mod auth;
 pub mod billing;

--- a/crates/spur-cloud-api/src/routes/sessions.rs
+++ b/crates/spur-cloud-api/src/routes/sessions.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,

--- a/crates/spur-cloud-api/src/routes/users.rs
+++ b/crates/spur-cloud-api/src/routes/users.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::{
     extract::{Path, State},
     http::StatusCode,

--- a/crates/spur-cloud-api/src/routes/ws.rs
+++ b/crates/spur-cloud-api/src/routes/ws.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::{
     extract::{Path, State, WebSocketUpgrade},
     http::StatusCode,

--- a/crates/spur-cloud-api/src/spur_client.rs
+++ b/crates/spur-cloud-api/src/spur_client.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{BTreeMap, HashMap};
 
 use kube::api::{Api, DeleteParams, PostParams};

--- a/crates/spur-cloud-api/src/ssh/mod.rs
+++ b/crates/spur-cloud-api/src/ssh/mod.rs
@@ -1,1 +1,4 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod service_manager;

--- a/crates/spur-cloud-api/src/ssh/service_manager.rs
+++ b/crates/spur-cloud-api/src/ssh/service_manager.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use k8s_openapi::api::core::v1::{Service, ServicePort, ServiceSpec};
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::api::{Api, DeleteParams, ObjectMeta, PostParams};

--- a/crates/spur-cloud-api/src/state.rs
+++ b/crates/spur-cloud-api/src/state.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::Arc;
 
 use sqlx::PgPool;

--- a/crates/spur-cloud-api/src/terminal/mod.rs
+++ b/crates/spur-cloud-api/src/terminal/mod.rs
@@ -1,1 +1,4 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod ws_handler;

--- a/crates/spur-cloud-api/src/terminal/ws_handler.rs
+++ b/crates/spur-cloud-api/src/terminal/ws_handler.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use axum::extract::ws::{Message, WebSocket};
 use futures_util::{SinkExt, StreamExt};
 use k8s_openapi::api::core::v1::Pod;

--- a/crates/spur-cloud-api/src/update.rs
+++ b/crates/spur-cloud-api/src/update.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Auto-update check for spur-cloud-api.
 //!
 //! On startup, queries the GitHub releases API for ROCm/spur-cloud

--- a/crates/spur-cloud-common/src/gpu_types.rs
+++ b/crates/spur-cloud-common/src/gpu_types.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/spur-cloud-common/src/lib.rs
+++ b/crates/spur-cloud-common/src/lib.rs
@@ -1,2 +1,5 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod gpu_types;
 pub mod session_types;

--- a/crates/spur-cloud-common/src/session_types.rs
+++ b/crates/spur-cloud-common/src/session_types.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;

--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Multi-stage build for spur-cloud-api
 FROM rust:1.88-bookworm AS builder
 

--- a/deploy/docker/Dockerfile.frontend
+++ b/deploy/docker/Dockerfile.frontend
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Multi-stage build for spur-cloud frontend
 FROM node:20-alpine AS builder
 

--- a/deploy/docker/Dockerfile.session
+++ b/deploy/docker/Dockerfile.session
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Base GPU session image with sshd
 # Build for AMD ROCm GPUs
 FROM rocm/pytorch:latest

--- a/deploy/docker/gpuaas-entrypoint.sh
+++ b/deploy/docker/gpuaas-entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 # Inject SSH keys from environment variable

--- a/scripts/check-license-headers.sh
+++ b/scripts/check-license-headers.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Checks that source files contain the SPDX license header.
+# Used by both the pre-commit hook and CI workflow.
+#
+# Usage:
+#   scripts/check-license-headers.sh          # check all tracked source files
+#   scripts/check-license-headers.sh file...  # check specific files only
+
+set -euo pipefail
+
+SPDX_TAG="SPDX-License-Identifier: Apache-2.0"
+
+check_file() {
+    local file="$1"
+    # Read enough lines to find the header (shebangs push it down a line or two)
+    if ! head -5 "$file" | grep -qF "$SPDX_TAG"; then
+        echo "  $file"
+        return 1
+    fi
+    return 0
+}
+
+# If arguments were passed, check only those files; otherwise check all tracked files.
+if [ $# -gt 0 ]; then
+    files=("$@")
+else
+    mapfile -t files < <(git ls-files -- '*.rs' '*.proto' '*.py' '*.sh' '**/Dockerfile*')
+fi
+
+failed=0
+missing=()
+
+for f in "${files[@]}"; do
+    [ -f "$f" ] || continue
+    if ! check_file "$f"; then
+        missing+=("$f")
+        failed=1
+    fi
+done
+
+if [ "$failed" -ne 0 ]; then
+    echo ""
+    echo "ERROR: ${#missing[@]} file(s) missing SPDX license header."
+    echo "Each source file (.rs, .proto, .py, .sh, Dockerfile) must contain:"
+    echo "  SPDX-License-Identifier: Apache-2.0"
+    echo ""
+    echo "For .rs and .proto files, add these lines at the top:"
+    echo "  // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved."
+    echo "  // SPDX-License-Identifier: Apache-2.0"
+    echo ""
+    echo "For .py and .sh files (after the shebang, if any):"
+    echo "  # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved."
+    echo "  # SPDX-License-Identifier: Apache-2.0"
+    exit 1
+fi
+
+echo "All source files have SPDX license headers."


### PR DESCRIPTION
Add pr-lint.yml to enforce conventional commit PR titles and run check-license-headers.sh on all tracked Rust, shell, and Dockerfile sources.

Add scripts/check-license-headers.sh and opt-in .githooks/pre-commit (cargo fmt + staged header check).

Apply AMD Apache-2.0 SPDX headers across the codebase so the new checks pass.